### PR TITLE
CU-8699j8f1r Update release workflow for MedCAT v2

### DIFF
--- a/.github/workflows/medcat-v2_release.yml
+++ b/.github/workflows/medcat-v2_release.yml
@@ -31,7 +31,7 @@ jobs:
           # NOTE: branch name is in line with version tag, except for the patch version
           BRANCH_NAME="${VERSION_TAG%.*}"  # This removes the patch version (everything after the second dot)
 
-          # Check out the corresponding release branch (e.g., medcat/0.1)
+          # Check out the corresponding release branch (e.g., medcat/v0.1)
           git checkout $BRANCH_NAME
 
           # Ensure the branch is up-to-date with the remote

--- a/.github/workflows/medcat-v2_release.yml
+++ b/.github/workflows/medcat-v2_release.yml
@@ -27,7 +27,7 @@ jobs:
           git fetch --all
 
           # Get the tag without the 'v' and strip the patch version
-          VERSION_TAG="${GITHUB_REF#refs/tags/v}"
+          VERSION_TAG="${GITHUB_REF#refs/tags/}"
           # NOTE: branch name is in line with version tag, except for the patch version
           BRANCH_NAME="${VERSION_TAG%.*}"  # This removes the patch version (everything after the second dot)
 

--- a/.github/workflows/medcat-v2_release.yml
+++ b/.github/workflows/medcat-v2_release.yml
@@ -3,7 +3,7 @@ name: medcat-v2 - Build Python Package
 on:
   push:
     tags:
-      - "v*"
+      - "medcat/v*"
 
 permissions:
   contents: write
@@ -28,12 +28,10 @@ jobs:
 
           # Get the tag without the 'v' and strip the patch version
           VERSION_TAG="${GITHUB_REF#refs/tags/v}"
-          VERSION_MAJOR_MINOR="${VERSION_TAG%.*}"  # This removes the patch version (everything after the second dot)
+          # NOTE: branch name is in line with version tag, except for the patch version
+          BRANCH_NAME="${VERSION_TAG%.*}"  # This removes the patch version (everything after the second dot)
 
-          # Construct the branch name (e.g., release/0.1)
-          BRANCH_NAME="release/$VERSION_MAJOR_MINOR"
-
-          # Check out the corresponding release branch (e.g., release/0.1)
+          # Check out the corresponding release branch (e.g., medcat/0.1)
           git checkout $BRANCH_NAME
 
           # Ensure the branch is up-to-date with the remote

--- a/medcat-v2/.release/prepare_minor_release.sh
+++ b/medcat-v2/.release/prepare_minor_release.sh
@@ -28,7 +28,7 @@ VERSION_TAG="medcat/v$VERSION"
 # Extract version components
 VERSION_MAJOR_MINOR="${VERSION%.*}"
 VERSION_PATCH="${VERSION##*.}"
-RELEASE_BRANCH="medcat/$VERSION_MAJOR_MINOR"
+RELEASE_BRANCH="medcat/v$VERSION_MAJOR_MINOR"
 
 # Helpers
 run_or_echo() {

--- a/medcat-v2/.release/prepare_minor_release.sh
+++ b/medcat-v2/.release/prepare_minor_release.sh
@@ -27,7 +27,7 @@ fi
 # Extract version components
 VERSION_MAJOR_MINOR="${VERSION%.*}"
 VERSION_PATCH="${VERSION##*.}"
-RELEASE_BRANCH="release/$VERSION_MAJOR_MINOR"
+RELEASE_BRANCH="medcat/$VERSION_MAJOR_MINOR"
 
 # Helpers
 run_or_echo() {

--- a/medcat-v2/.release/prepare_minor_release.sh
+++ b/medcat-v2/.release/prepare_minor_release.sh
@@ -23,6 +23,7 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "Error: version '$VERSION' must be in format X.Y.Z"
     exit 1
 fi
+VERSION_TAG="medcat/v$VERSION"
 
 # Extract version components
 VERSION_MAJOR_MINOR="${VERSION%.*}"
@@ -53,8 +54,8 @@ if git show-ref --quiet "refs/heads/$RELEASE_BRANCH" && [[ $FORCE == false ]]; t
     error_exit "Branch '$RELEASE_BRANCH' already exists. Use --force to override."
 fi
 
-if git show-ref --quiet "refs/tags/v$VERSION" && [[ $FORCE == false ]]; then
-    error_exit "Tag 'v$VERSION' already exists. Use --force to override."
+if git show-ref --quiet "refs/tags/$VERSION_TAG" && [[ $FORCE == false ]]; then
+    error_exit "Tag '$VERSION_TAG' already exists. Use --force to override."
 fi
 
 if [[ -n "$(git status --porcelain)" ]]; then
@@ -78,8 +79,8 @@ run_or_echo git add pyproject.toml
 run_or_echo git commit -m \"Bump version to $VERSION for release\"
 
 # Create and push tag
-run_or_echo git tag -a \"v$VERSION\" -m \"Release v$VERSION\"
+run_or_echo git tag -a \"$VERSION_TAG\" -m \"Release v$VERSION\"
 run_or_echo git push origin \"$RELEASE_BRANCH\"
-run_or_echo git push origin \"v$VERSION\"
+run_or_echo git push origin \"$VERSION_TAG\"
 
 run_or_echo git checkout main

--- a/medcat-v2/.release/prepare_patch_release.sh
+++ b/medcat-v2/.release/prepare_patch_release.sh
@@ -50,7 +50,7 @@ fi
 # Extract version components
 VERSION_MAJOR_MINOR="${VERSION%.*}"
 VERSION_PATCH="${VERSION##*.}"
-RELEASE_BRANCH="release/$VERSION_MAJOR_MINOR"
+RELEASE_BRANCH="medcat/$VERSION_MAJOR_MINOR"
 
 # some prerequisites
 [[ "$VERSION_PATCH" == "0" ]] && error_exit "Patch version must not be 0."

--- a/medcat-v2/.release/prepare_patch_release.sh
+++ b/medcat-v2/.release/prepare_patch_release.sh
@@ -51,7 +51,7 @@ VERSION_TAG="medcat/v$VERSION"
 # Extract version components
 VERSION_MAJOR_MINOR="${VERSION%.*}"
 VERSION_PATCH="${VERSION##*.}"
-RELEASE_BRANCH="medcat/$VERSION_MAJOR_MINOR"
+RELEASE_BRANCH="medcat/v$VERSION_MAJOR_MINOR"
 
 # some prerequisites
 [[ "$VERSION_PATCH" == "0" ]] && error_exit "Patch version must not be 0."

--- a/medcat-v2/.release/prepare_patch_release.sh
+++ b/medcat-v2/.release/prepare_patch_release.sh
@@ -46,6 +46,7 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "Error: version '$VERSION' must be in format X.Y.Z"
     exit 1
 fi
+VERSION_TAG="medcat/v$VERSION"
 
 # Extract version components
 VERSION_MAJOR_MINOR="${VERSION%.*}"
@@ -61,8 +62,8 @@ if ! git show-ref --verify --quiet "refs/remotes/origin/$RELEASE_BRANCH"; then
     error_exit "Release branch '$RELEASE_BRANCH' does not exist remotely."
 fi
 
-if git rev-parse "v$VERSION" >/dev/null 2>&1 && ! $FORCE; then
-    error_exit "Tag 'v$VERSION' already exists. Use --force to override."
+if git rev-parse "$VERSION_TAG" >/dev/null 2>&1 && ! $FORCE; then
+    error_exit "Tag '$VERSION_TAG' already exists. Use --force to override."
 fi
 
 if [[ -n "$(git status --porcelain)" && ! $FORCE ]]; then
@@ -82,9 +83,9 @@ if $MANUAL; then
     echo "  sed -i 's/version = \".*\"/version = \"$VERSION\"/' pyproject.toml"
     echo "  git add pyproject.toml"
     echo "  git commit -m 'Bump version to $VERSION'"
-    echo "  git tag -a v$VERSION -m 'Release v$VERSION'"
+    echo "  git tag -a $VERSION_TAG -m 'Release v$VERSION'"
     echo "  git push origin $RELEASE_BRANCH"
-    echo "  git push origin v$VERSION"
+    echo "  git push origin $VERSION_TAG"
     exit 0
 fi
 
@@ -162,9 +163,9 @@ run_or_echo git commit -m \"Bump version to $VERSION\" --allow-empty
 # now do the tagging
 # NOTE: can force since without the `--force` flag we would have checked
 #       for existing tag
-run_or_echo git tag -a \"v$VERSION\" -m \"Release v$VERSION\" --force
+run_or_echo git tag -a \"$VERSION_TAG\" -m \"Release v$VERSION\" --force
 run_or_echo git push origin \"$RELEASE_BRANCH\"
-run_or_echo git push origin \"v$VERSION\" --force
+run_or_echo git push origin \"$VERSION_TAG\" --force
 
 run_or_echo git checkout main
 


### PR DESCRIPTION
This would hopefully make it so that releases for MedCAT v2 make sense.

The changes
- Release branch is now `medcat/v<major>.<minor>`
  - Before just `release/v<major>.<minor>`
- Release tag now `medcat/v<major>.<minor>.<patch>`
  - Before just `v<major>.<minor>.<parch>`
- Makes changes to both the release scripts as well as the actual workflow