### PR TITLE
Update release tag

### DIFF
--- a/.github/workflows/medcat-v2_release.yml
+++ b/.github/workflows/medcat-v2_release.yml
@@ -30,6 +30,7 @@ jobs:
           VERSION_TAG="${GITHUB_REF#refs/tags/}"
           # NOTE: branch name is in line with version tag, except for the patch version
           BRANCH_NAME="${VERSION_TAG%.*}"  # This removes the patch version (everything after the second dot)
+          BRANCH_NAME="${BRANCH_NAME//-//}"  # this replaces the - in the version tag with the / in the release branch
 
           # Check out the corresponding release branch (e.g., medcat-v0.1)
           git checkout $BRANCH_NAME

--- a/medcat-v2/.release/README.md
+++ b/medcat-v2/.release/README.md
@@ -4,7 +4,7 @@ The scripts within here are designed to help preparing for and dealing with rele
 
 The main idea is to use the `prepare_release.sh` script from within the root of the project and it will delegate either to `prepare_minor_release.sh` or `prepare_patch_release.sh` as necessary.
 The workflow within the scripts is as follows:
-- Create or check out release branch (`release/v<major>.<minor>`)
+- Create or check out release branch (`medcat/v<major>.<minor>`)
 - Update version in `pyproject.toml`
 - Create a tag based on the version
 - Push both the branch as well as the tag to `origin`

--- a/medcat-v2/.release/prepare_minor_release.sh
+++ b/medcat-v2/.release/prepare_minor_release.sh
@@ -23,7 +23,7 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "Error: version '$VERSION' must be in format X.Y.Z"
     exit 1
 fi
-VERSION_TAG="medcat/v$VERSION"
+VERSION_TAG="medcat-v$VERSION"
 
 # Extract version components
 VERSION_MAJOR_MINOR="${VERSION%.*}"

--- a/medcat-v2/.release/prepare_patch_release.sh
+++ b/medcat-v2/.release/prepare_patch_release.sh
@@ -46,7 +46,7 @@ if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     echo "Error: version '$VERSION' must be in format X.Y.Z"
     exit 1
 fi
-VERSION_TAG="medcat/v$VERSION"
+VERSION_TAG="medcat-v$VERSION"
 
 # Extract version components
 VERSION_MAJOR_MINOR="${VERSION%.*}"


### PR DESCRIPTION
This will use `medcat-v<major>.<minor>.<patch>` for release tag instead of `medcat/v<major>.<minor>.<patch>`.

Fix on the workflow step as well as on the release scripts.