### PR TITLE
Small release documention fixes

### DIFF
--- a/.github/workflows/medcat-v2_release.yml
+++ b/.github/workflows/medcat-v2_release.yml
@@ -31,7 +31,7 @@ jobs:
           # NOTE: branch name is in line with version tag, except for the patch version
           BRANCH_NAME="${VERSION_TAG%.*}"  # This removes the patch version (everything after the second dot)
 
-          # Check out the corresponding release branch (e.g., medcat-v0.1)
+          # Check out the corresponding release branch (e.g., medcat/v0.1)
           git checkout $BRANCH_NAME
 
           # Ensure the branch is up-to-date with the remote

--- a/medcat-v2/.release/README.md
+++ b/medcat-v2/.release/README.md
@@ -7,6 +7,7 @@ The workflow within the scripts is as follows:
 - Create or check out release branch (`medcat/v<major>.<minor>`)
 - Update version in `pyproject.toml`
 - Create a tag based on the version
+  - This will be in the format `medcat/v<major>.<minor>.<patch>`
 - Push both the branch as well as the tag to `origin`
 
 The general usage for a minor release based on the `main` branch from within the **root of the project** is simply:

--- a/medcat-v2/.release/README.md
+++ b/medcat-v2/.release/README.md
@@ -4,7 +4,7 @@ The scripts within here are designed to help preparing for and dealing with rele
 
 The main idea is to use the `prepare_release.sh` script from within the root of the project and it will delegate either to `prepare_minor_release.sh` or `prepare_patch_release.sh` as necessary.
 The workflow within the scripts is as follows:
-- Create or check out release branch (`release/v<major>.<minor>`)
+- Create or check out release branch (`medcat/v<major>.<minor>`)
 - Update version in `pyproject.toml`
 - Create a tag based on the version
 - Push both the branch as well as the tag to `origin`


### PR DESCRIPTION
Just documentation fixes.

Changes:
1. Fix branch name in comment in release workflow
2. Update `medcat-v2/.release` folder README to include correct branch name
3. Update `medcat-v2/.release` folder README to incldue tag format