### PR TITLE
CU-8699pqzp5 Legacy conversion

### DIFF
--- a/medcat-v2/medcat/utils/legacy/convert_config.py
+++ b/medcat-v2/medcat/utils/legacy/convert_config.py
@@ -167,7 +167,8 @@ def get_config_from_nested_dict(old_data: dict) -> Config:
     # but we now default to regex
     cnf.general.nlp.provider = 'spacy'
     cnf = _make_changes(cnf, old_data)
-    if cnf.general.nlp.modelname in ('spacy_model', 'en_core_sci_md'):
+    if cnf.general.nlp.modelname in ('spacy_model', 'en_core_sci_md',
+                                     'en_core_sci_lg'):
         logger.info("Fixing spacy model. "
                     "Moving from '%s' to 'en_core_web_md'!",
                     cnf.general.nlp.modelname)


### PR DESCRIPTION
Fix a coule of minor legacy conversion issues with configs.

1. When a path for legacy config didn't exist, unexpected stuff would happen
2. When converting, deprecated `spacy` model (`en_core_sci_lg`) was allowed to move on.

This PR addresses both of those.