### PR TITLE
Cu 8699qbr8e Multiprocessing empty batches

### DIFF
--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -265,6 +265,9 @@ class CAT(AbstractSerialisable):
                     executor.submit(self._mp_worker_func, batch))
             except StopIteration:
                 break
+        if not futures:
+            # NOTE: if there wasn't any data, we didn't process anything
+            return
         # Main process works on next batch while workers are busy
         main_batch: Optional[list[tuple[str, str, bool]]]
         try:
@@ -282,6 +285,10 @@ class CAT(AbstractSerialisable):
         # so we're going to wait for them to finish, yield their results,
         # and subsequently submit the next batch to keep them busy
         for _ in range(external_processes):
+            if not futures:
+                # NOTE: if there's no futures then there can't be
+                #       anything to batch
+                break
             # Wait for any future to complete
             done_future = next(as_completed(futures))
             futures.remove(done_future)

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -418,12 +418,28 @@ class CATWithDictNERSupTrainingTests(CATSupTrainingTests):
             "The dog is sitting outside the house."
         ]
         ents = list(self.cat.get_entities_multi_texts(texts))
+        self.assert_ents(ents, texts)
+
+    def assert_ents(self, ents: list[tuple], texts: list[str]):
         self.assertEqual(len(ents), len(texts))
         # NOTE: text IDs are integers starting from 0
         exp_ids = set(str(i) for i in range(len(texts)))
         for ent_id_str, ent in ents:
             with self.subTest(f"Entity: {ent_id_str} [{ent}]"):
                 self.assertIn(ent_id_str, exp_ids)
+
+    def test_can_multiprocess_empty(self):
+        texts = []
+        ents = list(self.cat.get_entities_multi_texts(texts, n_process=3))
+        self.assert_ents(ents, texts)
+
+    def test_can_get_multiprocess(self):
+        texts = [
+            "The fittest most fit of chronic kidney failure",
+            "The dog is sitting outside the house."
+        ]
+        ents = list(self.cat.get_entities_multi_texts(texts, n_process=3))
+        self.assert_ents(ents, texts)
 
 
 class CATWithDocAddonTests(CATIncludingTests):


### PR DESCRIPTION
Turns out the current multiprocessing pipeline had a few issues.
It would work fine if number of process wasn't specified (since it would do them in sequence).

However, if the number of processes specified was 2 (or greater) processing an empty list of texts would fail. This was becaue the assumption of the method was that work would be distributed accross all workers, and subsequently there's a future for every worked. But in case of an empty input there were no futures.

Furthermore, if the number of processes was 3 (or greater), passing a small list of input texts also often resulted in an exception being raised. This is because with 2 processes, only 1 external worker is spawned, and it gets some texts to manage, and subsequently leaves nothing for the main process (which is fine). But if there's 3 processes, only 1 of the 2 extra processes gets any work. And as such, the assumption of the number of futures available to be waited for was incorrect.


This PR fixes the above issues.
It also adds a few simple tests to make sure they remain fixed.
NOTE: I ran the new tests without the change in this PR and they did in fact error out (as was expected due to the above).