### PR TITLE
Remove install bundles before pushing to PyPI

### DIFF
--- a/.github/workflows/medcat-v2_release.yml
+++ b/.github/workflows/medcat-v2_release.yml
@@ -204,6 +204,11 @@ jobs:
           files: |
             medcat-v2/dist/*
 
+      - name: Remove install bundles in preparations for PyPI push
+        run: |
+          rm dist/medcat-v${{ needs.build.outputs.version_only }}-*-cpu.tar.gz
+#          rm dist/medcat-v${{ needs.build.outputs.version_only }}-*-gpu.tar.gz
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
The PyPI install action would otherwise try to include all the `.tar.gz` files. And while checking some of the, it realises it has unexpected stuff in it, and fails.