### PR TITLE
CU-8699rvhe9 Refer to PyPI medcat v2

### DIFF
--- a/medcat-demo-app/webapp/requirements.txt
+++ b/medcat-demo-app/webapp/requirements.txt
@@ -2,5 +2,5 @@ Django==3.2.25
 django-dbbackup==4.0.0b0
 django-storages[boto3]==1.12.3
 django-cron==0.5.1
-medcat[meta-cat,spacy] @ git+https://github.com/CogStack/cogstack-nlp.git@refs/tags/medcat/v0.11.2#subdirectory=medcat-v2
+medcat[meta-cat,spacy]~=2.0.0b
 urllib3==1.26.18

--- a/medcat-service/Dockerfile
+++ b/medcat-service/Dockerfile
@@ -6,9 +6,6 @@ ENV CRYPTOGRAPHY_DONT_BUILD_RUST=1
 WORKDIR /cat
 COPY ./requirements.txt /cat
 
-# NOTE: need git for URL based installs
-RUN apt-get update && apt-get install -y git
-
 # Install Python dependencies
 ARG USE_CPU_TORCH=true
 # NOTE: Allow building without GPU so as to lower image size (GPU is disabled by default)

--- a/medcat-service/requirements.txt
+++ b/medcat-service/requirements.txt
@@ -6,7 +6,7 @@ setuptools==78.1.1
 simplejson==3.19.3
 werkzeug==3.1.3
 setuptools-rust==1.11.0
-medcat[meta-cat,spacy,deid] @ git+https://github.com/CogStack/cogstack-nlp.git@refs/tags/medcat/v0.13.5#subdirectory=medcat-v2
+medcat[meta-cat,spacy,deid]~=2.0.0b
 # pinned because of issues with de-id models and past models (it will not do any de-id)
 transformers>=4.34.0,<5.0.0
 requests==2.32.4

--- a/medcat-v2-tutorials/notebooks/introductory/meta/1._Add_a_MetaCat_to_a_Model.ipynb
+++ b/medcat-v2-tutorials/notebooks/introductory/meta/1._Add_a_MetaCat_to_a_Model.ipynb
@@ -76,7 +76,7 @@
     }
    ],
    "source": [
-    "! pip install \"medcat[meta-cat] @ git+https://github.com/CogStack/cogstack-nlp@medcat/v0.11.2#subdirectory=medcat-v2\" # NOTE: VERSION-STRING"
+    "! pip install medcat[meta-cat]~=2.0.0b # NOTE: VERSION-STRING"
    ]
   },
   {
@@ -330,7 +330,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": ".venv",
+   "display_name": ".venv_v2_tut",
    "language": "python",
    "name": "python3"
   },
@@ -344,7 +344,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.12"
   }
  },
  "nbformat": 4,

--- a/medcat-v2-tutorials/notebooks/introductory/migration/1._Migrate_v1_model_to_v2.ipynb
+++ b/medcat-v2-tutorials/notebooks/introductory/migration/1._Migrate_v1_model_to_v2.ipynb
@@ -131,7 +131,7 @@
     }
    ],
    "source": [
-    "! pip install \"medcat[meta-cat,spacy,deid] @ git+https://github.com/CogStack/cogstack-nlp@medcat/v0.11.2#subdirectory=medcat-v2\""
+    "! pip install medcat[meta-cat,spacy,deid]~=2.0.0b"
    ]
   },
   {

--- a/medcat-v2-tutorials/notebooks/introductory/relcat/1._Supervised_Training_Relation_Extraction.ipynb
+++ b/medcat-v2-tutorials/notebooks/introductory/relcat/1._Supervised_Training_Relation_Extraction.ipynb
@@ -101,7 +101,7 @@
    ],
    "source": [
     "# Install medcat\n",
-    "! pip install \"medcat[spacy,rel-cat,meta-cat] @ git+https://github.com/CogStack/cogstack-nlp@medcat/v0.11.2#subdirectory=medcat-v2\" # NOTE: VERSION-STRING"
+    "! pip install medcat~=2.0.0b # NOTE: VERSION-STRING"
    ]
   },
   {

--- a/medcat-v2-tutorials/requirements.txt
+++ b/medcat-v2-tutorials/requirements.txt
@@ -1,4 +1,4 @@
-medcat @ git+https://github.com/CogStack/cogstack-nlp@medcat/v0.11.2#subdirectory=medcat-v2
+medcat~=2.0.0b
 ipykernel
 pytest-xdist~=3.6.0
 nbmake<1.6

--- a/medcat-v2/README.md
+++ b/medcat-v2/README.md
@@ -42,20 +42,19 @@ If you wish you can also convert the v1 models into the v2 format (see tutorial 
 ## Installation
 
 Currently MedCAT v2 is in Beta.
-As such, we're not yet pushing to PyPI.
-And because of that the current installation command for (only) core MedCAT v2 is:
+As such, you need to explicitly specify the beta release.
 ```
-pip install "medcat @ git+https://github.com/CogStack/cogstack-nlp.git@refs/tags/medcat/v0.10.0#subdirectory=medcat-v2"
+pip install medcat~=2.0.0b
 ```
 Do note that **this installs only the core MedCAT v2**.
 **It does not necessary dependencies for `spacy`-based tokenizing or MetaCATs or DeID**.
 However, all of those are supported as well.
 You can install them as follows:
 ```
-pip install "medcat[spacy] @ git+https://github.com/CogStack/cogstack-nlp.git@refs/tags/medcat/v0.10.0#subdirectory=medcat-v2"  # for spacy-based tokenizer
-pip install "medcat[meta-cat] @ git+https://github.com/CogStack/cogstack-nlp.git@refs/tags/medcat/v0.10.0#subdirectory=medcat-v2"  # for MetaCAT
-pip install "medcat[deid] @ git+https://github.com/CogStack/cogstack-nlp.git@refs/tags/medcat/v0.10.0#subdirectory=medcat-v2"  # for DeID models
-pip install "medcat[spacy,meta-cat,deid,rel-cat,dict-ner] @ git+https://github.com/CogStack/cogstack-nlp.git@refs/tags/medcat/v0.10.0#subdirectory=medcat-v2"  # for all of the sbove
+pip install medcat[spacy]~=2.0.0b # for spacy-based tokenizer
+pip install medcat[meta-cat]~=2.0.0b  # for MetaCAT
+pip install medcat[deid]~=2.0.0b  # for DeID models
+pip install medcat[spacy,meta-cat,deid,rel-cat,dict-ner]~=2.0.0b  # for all of the above
 ```
 
 PS:
@@ -63,17 +62,6 @@ For in the above example, we're installing the MedCAT v2 BETA version of `v0.8.0
 The README is unlikely to change after every new release.
 If another version is available / required, substitute the version tag as appropriate.
 
-<!-- 
-To install the latest version of MedCAT run the following command:
-```
-pip install medcat
-```
-Normal installations of MedCAT will install torch-gpu and all relevant dependancies (such as CUDA). This can require as much as 10 GB more disk space, which isn't required for CPU only usage.
-
-To install the latest version of MedCAT without torch GPU support run the following command:
-```
-pip install medcat --extra_index_url https://download.pytorch.org/whl/cpu/
-``` -->
 ## Demo
 
 The MedCAT v2 demo web app is available [here](https://medcatv2.sites.er.kcl.ac.uk/).

--- a/medcat-v2/docs/main.md
+++ b/medcat-v2/docs/main.md
@@ -44,10 +44,15 @@ Some guides on how to use MedCAT v2 are available at [MedCAT Tutorials](https://
 ## Install using PIP (Requires Python 3.9+)
 Installation instructions are to follow upon a release of this version on PyPI.
 Though installation is likely to be simply `pip install "medcat>=2.0"` at that time.
-<!-- 0. Upgrade pip `pip install --upgrade pip`
-1. Install MedCAT
-- For macOS/linux: `pip install --upgrade medcat`
-- For Windows (see [PyTorch documentation](https://pytorch.org/get-started/previous-versions/)): `pip install --upgrade medcat -f https://download.pytorch.org/whl/torch_stable.html` -->
+Currently the installation for the 2.0 beta release is simply:
+```
+pip install medcat~=2.0.0b
+```
+Though note the extras you might need (e.g `spacy`, `meta-cat`, `rel-cat`, `deid`).
+If you need them, they need to be specified in brackets, e.g:
+```
+pip install medcat[spacy,meta-cat,rel-cat,deid]~=2.0.0b
+```
 
 2. Quickstart (MedCAT v2+):
 ```python


### PR DESCRIPTION
Now that there's a PyPI (beta) release of medcat v2, we can install based on that.

This involvest stuff that has a direct dependence on medcat (v2).
Due to not depending on installation based on GitHub repositories, the `medcat-service` image does not need `git` to build.
