### PR TITLE
CU-8699upt9a Allow saving output onto disk when multiprocessing

### DIFF
--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -18,6 +18,7 @@ from medcat.trainer import Trainer
 from medcat.storage.serialisers import serialise, AvailableSerialisers
 from medcat.storage.serialisers import deserialise
 from medcat.storage.serialisables import AbstractSerialisable
+from medcat.storage.mp_ents_save import BatchAnnotationSaver
 from medcat.utils.fileutils import ensure_folder_if_parent
 from medcat.utils.hasher import Hasher
 from medcat.pipeline.pipeline import Pipeline
@@ -159,7 +160,7 @@ class CAT(AbstractSerialisable):
     def _mp_worker_func(
             self,
             texts_and_indices: list[tuple[str, str, bool]]
-            ) -> list[tuple[str, str, Union[dict, Entities, OnlyCUIEntities]]]:
+            ) -> list[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
         # NOTE: this is needed for subprocess as otherwise they wouldn't have
         #       any of these set
         # NOTE: these need to by dynamic in case the extra's aren't included
@@ -180,7 +181,7 @@ class CAT(AbstractSerialisable):
             elif has_rel_cat and isinstance(addon, RelCATAddon):
                 addon._rel_cat._init_data_paths()
         return [
-            (text, text_index, self.get_entities(text, only_cui=only_cui))
+            (text_index, self.get_entities(text, only_cui=only_cui))
             for text, text_index, only_cui in texts_and_indices]
 
     def _generate_batches_by_char_length(
@@ -256,7 +257,8 @@ class CAT(AbstractSerialisable):
             self,
             executor: ProcessPoolExecutor,
             batch_iter: Iterator[list[tuple[str, str, bool]]],
-            external_processes: int
+            external_processes: int,
+            saver: Optional[BatchAnnotationSaver],
             ) -> Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
         futures: list[Future] = []
         # submit batches, one for each external processes
@@ -275,10 +277,10 @@ class CAT(AbstractSerialisable):
         try:
             main_batch = next(batch_iter)
             main_results = self._mp_worker_func(main_batch)
-
+            if saver:
+                saver(main_results)
             # Yield main process results immediately
-            for result in main_results:
-                yield result[1], result[2]
+            yield from main_results
 
         except StopIteration:
             main_batch = None
@@ -295,9 +297,12 @@ class CAT(AbstractSerialisable):
             done_future = next(as_completed(futures))
             futures.remove(done_future)
 
+            cur_results = done_future.result()
+            if saver:
+                saver(main_results)
+
             # Yield all results from this batch
-            for result in done_future.result():
-                yield result[1], result[2]
+            yield from cur_results
 
             # Submit next batch to keep workers busy
             try:
@@ -317,6 +322,8 @@ class CAT(AbstractSerialisable):
             n_process: int = 1,
             batch_size: int = -1,
             batch_size_chars: int = 1_000_000,
+            save_dir_path: Optional[str] = None,
+            batches_per_save: int = 20,
             ) -> Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
         """Get entities from multiple texts (potentially in parallel).
 
@@ -343,6 +350,16 @@ class CAT(AbstractSerialisable):
                 Each process will be given batch of texts with a total
                 number of characters not exceeding this value. Defaults
                 to 1,000,000 characters. Set to -1 to disable.
+            save_dir_path (Optional[str]):
+                The path to where (if specified) the results are saved.
+                The directory will have a `annotated_ids.pickle` file
+                containing the tuple[list[str], int] with a list of
+                indices already saved and then umber of parts already saved.
+                In addition there will be (usually multuple) files in the
+                `part_<num>.pickle` format with the partial outputs.
+            batches_per_save (int):
+                The number of patches to save (if `save_dir_path` is specified)
+                at once. Defaults to 20.
 
         Yields:
             Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
@@ -352,15 +369,27 @@ class CAT(AbstractSerialisable):
             Union[Iterator[str], Iterator[tuple[str, str]]], iter(texts))
         batch_iter = self._generate_batches(
             text_iter, batch_size, batch_size_chars, only_cui)
+        if save_dir_path:
+            saver = BatchAnnotationSaver(save_dir_path, batches_per_save)
+        else:
+            saver = None
         if n_process == 1:
             # just do in series
             for batch in batch_iter:
-                for _, text_index, result in self._mp_worker_func(batch):
-                    yield text_index, result
+                batch_results = self._mp_worker_func(batch)
+                if saver is not None:
+                    saver(batch_results)
+                yield from batch_results
+            if saver:
+                # save remainder
+                saver._save_cache()
             return
 
         with self._no_usage_monitor_exit_flushing():
-            yield from self._multiprocess(n_process, batch_iter)
+            yield from self._multiprocess(n_process, batch_iter, saver)
+        if saver:
+            # save remainder
+            saver._save_cache()
 
     @contextmanager
     def _no_usage_monitor_exit_flushing(self):
@@ -379,7 +408,8 @@ class CAT(AbstractSerialisable):
 
     def _multiprocess(
             self, n_process: int,
-            batch_iter: Iterator[list[tuple[str, str, bool]]]
+            batch_iter: Iterator[list[tuple[str, str, bool]]],
+            saver: Optional[BatchAnnotationSaver],
             ) -> Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
         external_processes = n_process - 1
         if self.FORCE_SPAWN_MP:
@@ -391,7 +421,7 @@ class CAT(AbstractSerialisable):
             mp.set_start_method("spawn", force=True)
         with ProcessPoolExecutor(max_workers=external_processes) as executor:
             yield from self._mp_one_batch_per_process(
-                executor, batch_iter, external_processes)
+                executor, batch_iter, external_processes, saver=saver)
 
     def _get_entity(self, ent: MutableEntity,
                     doc_tokens: list[str],

--- a/medcat-v2/medcat/storage/mp_ents_save.py
+++ b/medcat-v2/medcat/storage/mp_ents_save.py
@@ -1,0 +1,60 @@
+from typing import Union
+import os
+import logging
+
+import pickle
+
+from medcat.data.entities import Entities, OnlyCUIEntities
+
+
+logger = logging.getLogger(__name__)
+
+
+class BatchAnnotationSaver:
+    def __init__(self, save_dir: str, batches_per_save: int):
+        self.save_dir = save_dir
+        self.batches_per_save = batches_per_save
+        self._batch_cache: list[list[
+            tuple[str, Union[dict, Entities, OnlyCUIEntities]]]] = []
+        os.makedirs(save_dir, exist_ok=True)
+        self.part_number = 0
+        self.annotated_ids_path = os.path.join(
+            save_dir, "annotated_ids.pickle")
+
+    def _load_existing_ids(self) -> tuple[list[str], int]:
+        if not os.path.exists(self.annotated_ids_path):
+            return [], -1
+        with open(self.annotated_ids_path, 'rb') as f:
+            return pickle.load(f)
+
+    def _save_cache(self):
+        annotated_ids, prev_part_num = self._load_existing_ids()
+        if (prev_part_num + 1) != self.part_number:
+            logger.info(
+                "Found part number %d off disk. Previously %d was kept track "
+                "of in code. Updating to %d off disk.",
+                prev_part_num, self.part_number, prev_part_num)
+            self.part_number = prev_part_num
+        for batch in self._batch_cache:
+            for doc_id, _ in batch:
+                annotated_ids.append(doc_id)
+        logger.debug("Saving part %d with %d batches",
+                     self.part_number, len(self._batch_cache))
+        with open(self.annotated_ids_path, 'wb') as f:
+            pickle.dump((annotated_ids, self.part_number), f)
+        # Save batch as part_<num>.pickle
+        part_path = os.path.join(self.save_dir,
+                                 f"part_{self.part_number}.pickle")
+        part_dict = {id: val for
+                     batch in self._batch_cache for
+                     id, val in batch}
+        with open(part_path, 'wb') as f:
+            pickle.dump(part_dict, f)
+        self._batch_cache.clear()
+        self.part_number += 1
+
+    def __call__(self, batch: list[
+            tuple[str, Union[dict, Entities, OnlyCUIEntities]]]):
+        self._batch_cache.append(batch)
+        if len(self._batch_cache) >= self.batches_per_save:
+            self._save_cache()


### PR DESCRIPTION
This PR allows one to save data to disk when multiprocessing.
The main goal was to leave the saved output as similar to v1's `cat.multiprocessing_batch_char_size` as possible.

It does so by adding a pair of new arguments to the `CAT.get_entities_multi_texts` method:
- `save_dir_path: Optional[str] = None` - if specified, the path to be used for the data
- `batches_per_save: int = 20` - the number of batches to save at once

In addition, it adds a new module
- `medcat.storage.mp_ents_save`
- Which is responsible for the saving action
- So that it's not cluttering the `cat.py` module

There's also a minor test suite to make sure
- The saved files are in order
  - All indices are saved in the `annotated_ids.pickle`
  - All parts (`part_<num>.pickle`) are accounted for
- All the output is saved
  - All the parts texts' output is saved in various parts
  - The output from the method is equal to the saved data