### PR TITLE
CU-8699vkmu4: Allow load with merging config(s)

### DIFF
--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -49,6 +49,7 @@ class CAT(AbstractSerialisable):
                  vocab: Union[Vocab, None] = None,
                  config: Optional[Config] = None,
                  model_load_path: Optional[str] = None,
+                 config_dict: Optional[dict] = None
                  ) -> None:
         self.cdb = cdb
         self.vocab = vocab
@@ -60,6 +61,8 @@ class CAT(AbstractSerialisable):
         elif config is not None:
             self.cdb.config = config
         self.config = config
+        if config_dict:
+            self.config.merge_config(config_dict)
 
         self._trainer: Optional[Trainer] = None
         self._pipeline = self._recreate_pipe(model_load_path)
@@ -668,11 +671,14 @@ class CAT(AbstractSerialisable):
         return model_pack_path
 
     @classmethod
-    def load_model_pack(cls, model_pack_path: str) -> 'CAT':
+    def load_model_pack(cls, model_pack_path: str,
+                        config_dict: Optional[dict] = None) -> 'CAT':
         """Load the model pack from file.
 
         Args:
             model_pack_path (str): The model pack path.
+            config_dict (Optional[dict]): The model config to
+                merge in before initialising the pipe. Defaults to None.
 
         Raises:
             ValueError: If the saved data does not represent a model pack.
@@ -703,7 +709,8 @@ class CAT(AbstractSerialisable):
                             TOKENIZER_PREFIX,
                             # components will be loaded semi-manually
                             # within the creation of pipe
-                            COMPONENTS_FOLDER})
+                            COMPONENTS_FOLDER},
+                          config_dict=config_dict)
         # NOTE: deserialising of components that need serialised
         #       will be dealt with upon pipeline creation automatically
         if not isinstance(cat, CAT):

--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -748,16 +748,19 @@ class CAT(AbstractSerialisable):
 
     @classmethod
     def load_addons(
-            cls, model_pack_path: str, meta_cat_config_dict: Optional[dict] = None
+            cls, model_pack_path: str,
+            addon_config_dict: Optional[dict[str, dict]] = None
             ) -> list[tuple[str, AddonComponent]]:
         """Load addons based on a model pack path.
 
         Args:
             model_pack_path (str): path to model pack, zip or dir.
-            meta_cat_config_dict (Optional[dict]):
-                A config dict that will overwrite existing configs in meta_cat.
-                e.g. meta_cat_config_dict = {'general': {'device': 'cpu'}}.
-                Defaults to None.
+            addon_config_dict (Optional[dict]): The Addon-specific
+                config dict to merge in before pipe initialisation.
+                If specified, it needs to have an addon dict per name.
+                For instance,
+                `{"meta_cat.Subject": {'general': {'device': 'cpu'}}}`
+                would apply to the specific MetaCAT.
 
         Returns:
             List[tuple(str, AddonComponent)]: list of pairs of adddon names the addons.
@@ -775,9 +778,9 @@ class CAT(AbstractSerialisable):
         loaded_addons = [
             addon for addon_path, addon_name in addon_paths_and_names
             if isinstance(addon := (
-                deserialise(addon_path, model_config=meta_cat_config_dict)
-                if ('meta_cat' in addon_name and meta_cat_config_dict)
-                else deserialise(addon_path)
+                deserialise(addon_path, model_config=addon_config_dict.get(addon_name))
+                if addon_config_dict else
+                deserialise(addon_path)
                 ), AddonComponent)
         ]
         return [(addon.full_name, addon) for addon in loaded_addons]

--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -747,16 +747,20 @@ class CAT(AbstractSerialisable):
         components_folder = os.path.join(model_pack_path, COMPONENTS_FOLDER)
         if not os.path.exists(components_folder):
             return []
-        addon_paths = [
-            folder_path
+        addon_paths_and_names = [
+            (folder_path, folder_name.removeprefix(AddonComponent.NAME_PREFIX))
             for folder_name in os.listdir(components_folder)
             if os.path.isdir(folder_path := os.path.join(
                 components_folder, folder_name))
             and folder_name.startswith(AddonComponent.NAME_PREFIX)
         ]
         loaded_addons = [
-            addon for addon_path in addon_paths
-            if isinstance(addon := deserialise(addon_path), AddonComponent)
+            addon for addon_path, addon_name in addon_paths_and_names
+            if isinstance(addon := (
+                deserialise(addon_path, model_config=meta_cat_config_dict)
+                if ('meta_cat' in addon_name and meta_cat_config_dict)
+                else deserialise(addon_path)
+                ), AddonComponent)
         ]
         return [(addon.full_name, addon) for addon in loaded_addons]
 

--- a/medcat-v2/medcat/components/addons/meta_cat/meta_cat.py
+++ b/medcat-v2/medcat/components/addons/meta_cat/meta_cat.py
@@ -221,6 +221,8 @@ class MetaCATAddon(AddonComponent):
                 "Inferring config from file at '%s'", folder_path,
                 config_path)
             cnf = ConfigMetaCAT.load(config_path)
+        if 'model_config' in init_kwargs:
+            cnf.merge_config(init_kwargs['model_config'])
         if 'tokenizer' in init_kwargs:
             tokenizer = init_kwargs['tokenizer']
         else:

--- a/medcat-v2/medcat/pipeline/pipeline.py
+++ b/medcat-v2/medcat/pipeline/pipeline.py
@@ -72,7 +72,8 @@ class Pipeline:
     def __init__(self, cdb: CDB, vocab: Optional[Vocab],
                  model_load_path: Optional[str],
                  # NOTE: upon reload, old pipe can be useful
-                 old_pipe: Optional['Pipeline'] = None):
+                 old_pipe: Optional['Pipeline'] = None,
+                 addon_config_dict: Optional[dict[str, dict]] = None):
         self.cdb = cdb
         # NOTE: Vocab is None in case of DeID models and thats fine then,
         #       but it should be non-None otherwise
@@ -81,7 +82,7 @@ class Pipeline:
         self._tokenizer = self._init_tokenizer()
         self._components: list[CoreComponent] = []
         self._addons: list[AddonComponent] = []
-        self._init_components(model_load_path, old_pipe)
+        self._init_components(model_load_path, old_pipe, addon_config_dict)
 
     @property
     def tokenizer(self) -> BaseTokenizer:
@@ -172,8 +173,44 @@ class Pipeline:
                 f"'{comp.get_type().name}' instead.")
         return comp
 
+    def _attempt_merge(
+            self, addon_cnf: ComponentConfig,
+            addon_config_dict: dict[str, dict]) -> None:
+        for name, config_dict in addon_config_dict.items():
+            if not name.startswith(addon_cnf.comp_name):
+                continue
+            # TODO: is there an option to do this in a more general way?
+            #       right now it's an implementation-specific code smell
+            if isinstance(addon_cnf, ConfigMetaCAT):
+                full_name = f"{addon_cnf.comp_name}.{addon_cnf.general.category_name}"
+                if name == full_name:
+                    addon_cnf.merge_config(config_dict)
+                    return
+            else:
+                logger.warning(
+                    "No implementation specified for defining if/when %s"
+                    "should apply to addon config (e.g %s)",
+                    type(addon_cnf).__name__, name)
+                # if only 1 of the type, then just merge
+                similars = [cd for oname, cd in addon_config_dict.items()
+                            if oname.startswith(addon_cnf.comp_name)]
+                if len(similars) == 1:
+                    logger.warning(
+                        "Since there is only 1 config for this type (%s) specified "
+                        "we will just merge the configs (@%s).",
+                        addon_cnf.comp_name, name)
+                    addon_cnf.merge_config(config_dict)
+                    return
+                else:
+                    logger.warning(
+                        "There are %d similar configs (%s) specified, so unable to "
+                        "merge the config since it's ambiguous (@%s)",
+                        len(similars), addon_cnf.comp_name, name)
+
     def _init_components(self, model_load_path: Optional[str],
-                         old_pipe: Optional['Pipeline']) -> None:
+                         old_pipe: Optional['Pipeline'],
+                         addon_config_dict: Optional[dict[str, dict]],
+                         ) -> None:
         (loaded_core_component_paths,
          loaded_addon_component_paths) = self._get_loaded_components_paths(
              model_load_path)
@@ -186,6 +223,8 @@ class Pipeline:
                     CoreComponentType[cct_name], model_load_path)
             self._components.append(comp)
         for addon_cnf in self.config.components.addons:
+            if addon_config_dict:
+                self._attempt_merge(addon_cnf, addon_config_dict)
             addon = self._init_addon(
                 addon_cnf, loaded_addon_component_paths, old_pipe)
             # mark as not dirty at loat / init time

--- a/medcat-v2/medcat/pipeline/pipeline.py
+++ b/medcat-v2/medcat/pipeline/pipeline.py
@@ -173,8 +173,9 @@ class Pipeline:
                 f"'{comp.get_type().name}' instead.")
         return comp
 
+    @classmethod
     def _attempt_merge(
-            self, addon_cnf: ComponentConfig,
+            cls, addon_cnf: ComponentConfig,
             addon_config_dict: dict[str, dict]) -> None:
         for name, config_dict in addon_config_dict.items():
             if not name.startswith(addon_cnf.comp_name):

--- a/medcat-v2/medcat/pipeline/pipeline.py
+++ b/medcat-v2/medcat/pipeline/pipeline.py
@@ -187,26 +187,26 @@ class Pipeline:
                 if name == full_name:
                     addon_cnf.merge_config(config_dict)
                     return
+                continue
+            logger.warning(
+                "No implementation specified for defining if/when %s"
+                "should apply to addon config (e.g %s)",
+                type(addon_cnf).__name__, name)
+            # if only 1 of the type, then just merge
+            similars = [cd for oname, cd in addon_config_dict.items()
+                        if oname.startswith(addon_cnf.comp_name)]
+            if len(similars) == 1:
+                logger.warning(
+                    "Since there is only 1 config for this type (%s) specified "
+                    "we will just merge the configs (@%s).",
+                    addon_cnf.comp_name, name)
+                addon_cnf.merge_config(config_dict)
+                return
             else:
                 logger.warning(
-                    "No implementation specified for defining if/when %s"
-                    "should apply to addon config (e.g %s)",
-                    type(addon_cnf).__name__, name)
-                # if only 1 of the type, then just merge
-                similars = [cd for oname, cd in addon_config_dict.items()
-                            if oname.startswith(addon_cnf.comp_name)]
-                if len(similars) == 1:
-                    logger.warning(
-                        "Since there is only 1 config for this type (%s) specified "
-                        "we will just merge the configs (@%s).",
-                        addon_cnf.comp_name, name)
-                    addon_cnf.merge_config(config_dict)
-                    return
-                else:
-                    logger.warning(
-                        "There are %d similar configs (%s) specified, so unable to "
-                        "merge the config since it's ambiguous (@%s)",
-                        len(similars), addon_cnf.comp_name, name)
+                    "There are %d similar configs (%s) specified, so unable to "
+                    "merge the config since it's ambiguous (@%s)",
+                    len(similars), addon_cnf.comp_name, name)
 
     def _init_components(self, model_load_path: Optional[str],
                          old_pipe: Optional['Pipeline'],

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -313,8 +313,9 @@ class CatWithMetaCATSaveLoadTests(CatWithMetaCATTests):
 
     def test_can_load_meta_cat_with_addon_cnf(self, seed: int = -41):
         mc: MetaCATAddon = cat.CAT.load_addons(
-            self.mpp, meta_cat_config_dict={
-                "general": {"seed": seed}})[0][1]
+            self.mpp, addon_config_dict={
+                "meta_cat.Status": {
+                    "general": {"seed": seed}}})[0][1]
         self.assertEqual(mc.config.general.seed, seed)
 
     def test_can_merge_cnf_upon_load(self, use_seed: int = -4):

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -71,6 +71,19 @@ class TrainedModelTests(unittest.TestCase):
             cls.model.config.components.linking.train = False
 
 
+class ConfigMergeTests(unittest.TestCase):
+    spacy_model_name = 'en_core_web_lg'
+    model_dict = {
+        "general": {'nlp': {"modelname": spacy_model_name}}
+    }
+
+    def test_can_merge_config(self):
+        model = cat.CAT.load_model_pack(
+            EXAMPLE_MODEL_PACK_ZIP, config_dict=self.model_dict)
+        self.assertEqual(
+            model.config.general.nlp.modelname, self.spacy_model_name)
+
+
 class InferenceFromLoadedTests(TrainedModelTests):
 
     def test_can_load_model(self):

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -317,6 +317,15 @@ class CatWithMetaCATSaveLoadTests(CatWithMetaCATTests):
                 "general": {"seed": seed}})[0][1]
         self.assertEqual(mc.config.general.seed, seed)
 
+    def test_can_merge_cnf_upon_load(self, use_seed: int = -4):
+        loaded = cat.CAT.load_model_pack(
+            self.mpp,
+            addon_config_dict={
+                "meta_cat.Status": {"general": {"seed": use_seed}}
+            })
+        addon: MetaCATAddon = list(loaded._pipeline.iter_addons())[0]
+        self.assertEqual(addon.config.general.seed, use_seed)
+
 
 class CatWithChangesMetaCATTests(CatWithMetaCATTests):
     EXPECTED_HASH = "0b22401059a08380"

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -298,6 +298,12 @@ class CatWithMetaCATSaveLoadTests(CatWithMetaCATTests):
         _, addon = addons[0]
         self.assertIsInstance(addon, MetaCATAddon)
 
+    def test_can_load_meta_cat_with_addon_cnf(self, seed: int = -41):
+        mc: MetaCATAddon = cat.CAT.load_addons(
+            self.mpp, meta_cat_config_dict={
+                "general": {"seed": seed}})[0][1]
+        self.assertEqual(mc.config.general.seed, seed)
+
 
 class CatWithChangesMetaCATTests(CatWithMetaCATTests):
     EXPECTED_HASH = "0b22401059a08380"


### PR DESCRIPTION
This PR adds the following functionatlity:
- Allows a `config_dict` to be passed to `CAT.load_model_pack` to merge a config before the pipe is initialised
- Allows a `addon_config_dict` to be passed to `CAT.load_model_pack` to merge in addon-specific config(s) before addon initialisation
  - This expects the name (e.g `meta_cat.Subject`) to be mapped to the config for that addon
- Allows `addon_config_dict` to be passed to `CAT.load_addons` to merge addon-specific config(s) before their initialisation
  - Similarly to the above
- Adds a few tests regarding the above