### PR TITLE
CU-8699vnuwf Ignore hidden files when loading model packs

### DIFF
--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -703,7 +703,9 @@ class CAT(AbstractSerialisable):
                             TOKENIZER_PREFIX,
                             # components will be loaded semi-manually
                             # within the creation of pipe
-                            COMPONENTS_FOLDER})
+                            COMPONENTS_FOLDER,
+                            # ignore hidden files/folders
+                            '.'})
         # NOTE: deserialising of components that need serialised
         #       will be dealt with upon pipeline creation automatically
         if not isinstance(cat, CAT):


### PR DESCRIPTION
During model pack load, all folders are attempted to be deserialised.
However, if there's hidden / unexpected files, those could mess things up because they're not in the expected format.

This PR will fix the above by ignoring hidden (`.`-prefixed) folders when loading model packs.


The test added failed without this change.

The change itself was pretty trivial.