### PR TITLE
CU-8699vq0he: Improve addon access from CAT

### DIFF
--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -842,13 +842,31 @@ class CAT(AbstractSerialisable):
     # addon (e.g MetaCAT) related stuff
 
     def add_addon(self, addon: AddonComponent) -> None:
+        """Add the addon to the model pack an pipe.
+
+        Args:
+            addon (AddonComponent): The addon to add.
+        """
         self.config.components.addons.append(addon.config)
         self._pipeline.add_addon(addon)
 
     def get_addons(self) -> list[AddonComponent]:
+        """Get the list of all addons in this model pack.
+
+        Returns:
+            list[AddonComponent]: The list of addons present.
+        """
         return list(self._pipeline.iter_addons())
 
     def get_addons_of_type(self, addon_type: Type[AddonType]) -> list[AddonType]:
+        """Get a list of addons of a specific type.
+
+        Args:
+            addon_type (Type[AddonType]): The type of addons to look for.
+
+        Returns:
+            list[AddonType]: The list of addons of this specific type.
+        """
         return [
             addon for addon in self.get_addons()
             if isinstance(addon, addon_type)


### PR DESCRIPTION
This adds a few methods to simplify access to all addons or a subset diretly from `CAT`:
- `CAT.get_addons(self) -> list[AddonComponent]`
- `CAT.get_addons_of_type(self, addon_type: Type[AddonType]) -> list[AddonType]`