### PR TITLE
CU-8699zxxnt: Fix v2 tutorials link to point to correct version

### DIFF
--- a/medcat-v2/README.md
+++ b/medcat-v2/README.md
@@ -67,7 +67,7 @@ If another version is available / required, substitute the version tag as approp
 The MedCAT v2 demo web app is available [here](https://medcatv2.sites.er.kcl.ac.uk/).
 
 ## Tutorials
-A guide on how to use MedCAT v2 is available at [MedCATv2 Tutorials](https://github.com/CogStack/MedCATv2tutorials/).
+A guide on how to use MedCAT v2 is available at [MedCATv2 Tutorials](https://github.com/CogStack/cogstack-nlp/tree/main/medcat-v2-tutorials).
 However, the tutorials are a bit of a work in progress at this point in time.
 
 


### PR DESCRIPTION
The previous link pointed to the archived / old v2 tutorials.