### PR TITLE
build(medcat-trainer): Fix pypi publish CU-869a1x4fh

### DIFF
--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -2,7 +2,7 @@ name: medcat-trainer qa-build
 
 on:
   push:
-    branches: [ main ]
+
 
 defaults:
   run:
@@ -48,7 +48,7 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
-          packages-dir: medcat-trainer/dist
+          packages-dir: client/dist
 
   # Build and test webapp container
   build-and-push:

--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -2,7 +2,7 @@ name: medcat-trainer qa-build
 
 on:
   push:
-
+    branches: [ main ]
 
 defaults:
   run:

--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
-          packages_dir: client/dist
+          packages_dir: medcat-trainer/client/dist
 
   # Build and test webapp container
   build-and-push:

--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -2,7 +2,7 @@ name: medcat-trainer qa-build
 
 on:
   push:
-
+    branches: [ main ]
 
 defaults:
   run:
@@ -75,7 +75,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Push to DockerHub
         run: |

--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           password: ${{ secrets.TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
-          packages-dir: client/dist
+          packages_dir: client/dist
 
   # Build and test webapp container
   build-and-push:

--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -2,7 +2,7 @@ name: medcat-trainer qa-build
 
 on:
   push:
-    branches: [ main ]
+
 
 defaults:
   run:

--- a/.github/workflows/medcat-trainer_release.yml
+++ b/.github/workflows/medcat-trainer_release.yml
@@ -52,7 +52,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages-dir: medcat-trainer/dist
+          packages-dir: client/dist
 
   # Build and test webapp container
   build-and-push:

--- a/.github/workflows/medcat-trainer_release.yml
+++ b/.github/workflows/medcat-trainer_release.yml
@@ -52,6 +52,7 @@ jobs:
         if: startsWith(github.ref, 'refs/tags') && ! github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
+          # TODO CU-869a25n7e Use Trusted Platform Publisher based PyPI release
           password: ${{ secrets.PYPI_API_TOKEN }}
           packages_dir: medcat-trainer/client/dist
 

--- a/.github/workflows/medcat-trainer_release.yml
+++ b/.github/workflows/medcat-trainer_release.yml
@@ -20,7 +20,8 @@ jobs:
           ref: "main"
 
       - name: Release Tag
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+        # If GITHUB_REF=refs/tags/medcat-trainer/v0.1.2, this returns v0.1.2. Note it's including the "v" though it probably shouldnt
+        run: echo "RELEASE_VERSION=${GITHUB_REF##refs/*/}" >> $GITHUB_ENV
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -52,7 +53,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages_dir: client/dist
+          packages_dir: medcat-trainer/client/dist
 
   # Build and test webapp container
   build-and-push:

--- a/.github/workflows/medcat-trainer_release.yml
+++ b/.github/workflows/medcat-trainer_release.yml
@@ -52,7 +52,7 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
-          packages-dir: client/dist
+          packages_dir: client/dist
 
   # Build and test webapp container
   build-and-push:

--- a/.github/workflows/medcat-trainer_release.yml
+++ b/.github/workflows/medcat-trainer_release.yml
@@ -85,7 +85,7 @@ jobs:
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Push to DockerHub
         env:

--- a/.github/workflows/medcat-v1_main.yml
+++ b/.github/workflows/medcat-v1_main.yml
@@ -74,13 +74,11 @@ jobs:
           python tests/check_deprecations.py "$VERSION" --next-version --remove-prefix
 
   publish-to-test-pypi:
-    # Disable pypy publish waiting for TEST_PYPI_API_TOKEN
     if: |
       github.repository == 'CogStack/cogstack-nlp' &&
       github.ref == 'refs/heads/main' &&
       github.event_name == 'push' &&
-      startsWith(github.ref, 'refs/tags') != true &&
-      false 
+      startsWith(github.ref, 'refs/tags') != true
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     concurrency: publish-to-test-pypi

--- a/.github/workflows/medcat-v1_production.yml
+++ b/.github/workflows/medcat-v1_production.yml
@@ -1,6 +1,5 @@
 # TODO: Fix Medcat V1 Release Actions
 # Disabled waiting for designed release process
-# Disabled waiting for PYPI_API_TOKEN
 name: medcat-v1 - production
 
 on:
@@ -18,8 +17,7 @@ jobs:
     runs-on: ubuntu-24.04
     concurrency: build-n-publish-to-pypi
     if: | 
-     github.repository == 'CogStack/cogstack-nlp' &&
-     false   
+     github.repository == 'CogStack/cogstack-nlp'
 
     steps:
       - name: Checkout production
@@ -65,4 +63,5 @@ jobs:
         if: startsWith(github.ref, 'refs/tags') && ! github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
+          # TODO CU-869a25n7e Use Trusted Platform Publisher based PyPI release
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
https://github.com/CogStack/cogstack-nlp/actions/runs/16799617477/job/47577705902

```
Warning: Unexpected input(s) 'packages-dir', valid inputs are ['entryPoint', 'args', 'user', 'password', 'repository_url', 'packages_dir', 'verify_metadata', 'skip_existing', 'verbose']
Run pypa/gh-action-pypi-publish@v1.4.2
  with:
    repository_url: https://test.pypi.org/legacy/
    packages-dir: medcat-trainer/dist
    user: __token__
    packages_dir: dist
    verify_metadata: true
    skip_existing: false
    verbose: false
  env:
    pythonLocation: /opt/hostedtoolcache/Python/3.10.18/x64
    PKG_CONFIG_PATH: /opt/hostedtoolcache/Python/3.10.18/x64/lib/pkgconfig
    Python_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.18/x64
    Python2_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.18/x64
    Python3_ROOT_DIR: /opt/hostedtoolcache/Python/3.10.18/x64
    LD_LIBRARY_PATH: /opt/hostedtoolcache/Python/3.10.18/x64/lib
/usr/bin/docker run --name d926506e9ad883586e454f8d4c1b5a303cbaf6_438699 --label d92650 --workdir /github/workspace --rm -e "pythonLocation" -e "PKG_CONFIG_PATH" -e "Python_ROOT_DIR" -e "Python2_ROOT_DIR" -e "Python3_ROOT_DIR" -e "LD_LIBRARY_PATH" -e "INPUT_PASSWORD" -e "INPUT_REPOSITORY_URL" -e "INPUT_PACKAGES-DIR" -e "INPUT_USER" -e "INPUT_PACKAGES_DIR" -e "INPUT_VERIFY_METADATA" -e "INPUT_SKIP_EXISTING" -e "INPUT_VERBOSE" -e "HOME" -e "GITHUB_JOB" -e "GITHUB_REF" -e "GITHUB_SHA" -e "GITHUB_REPOSITORY" -e "GITHUB_REPOSITORY_OWNER" -e "GITHUB_REPOSITORY_OWNER_ID" -e "GITHUB_RUN_ID" -e "GITHUB_RUN_NUMBER" -e "GITHUB_RETENTION_DAYS" -e "GITHUB_RUN_ATTEMPT" -e "GITHUB_ACTOR_ID" -e "GITHUB_ACTOR" -e "GITHUB_WORKFLOW" -e "GITHUB_HEAD_REF" -e "GITHUB_BASE_REF" -e "GITHUB_EVENT_NAME" -e "GITHUB_SERVER_URL" -e "GITHUB_API_URL" -e "GITHUB_GRAPHQL_URL" -e "GITHUB_REF_NAME" -e "GITHUB_REF_PROTECTED" -e "GITHUB_REF_TYPE" -e "GITHUB_WORKFLOW_REF" -e "GITHUB_WORKFLOW_SHA" -e "GITHUB_REPOSITORY_ID" -e "GITHUB_TRIGGERING_ACTOR" -e "GITHUB_WORKSPACE" -e "GITHUB_ACTION" -e "GITHUB_EVENT_PATH" -e "GITHUB_ACTION_REPOSITORY" -e "GITHUB_ACTION_REF" -e "GITHUB_PATH" -e "GITHUB_ENV" -e "GITHUB_STEP_SUMMARY" -e "GITHUB_STATE" -e "GITHUB_OUTPUT" -e "RUNNER_OS" -e "RUNNER_ARCH" -e "RUNNER_NAME" -e "RUNNER_ENVIRONMENT" -e "RUNNER_TOOL_CACHE" -e "RUNNER_TEMP" -e "RUNNER_WORKSPACE" -e "ACTIONS_RUNTIME_URL" -e "ACTIONS_RUNTIME_TOKEN" -e "ACTIONS_CACHE_URL" -e "ACTIONS_RESULTS_URL" -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/home/runner/work/_temp/_github_home":"/github/home" -v "/home/runner/work/_temp/_github_workflow":"/github/workflow" -v "/home/runner/work/_temp/_runner_file_commands":"/github/file_commands" -v "/home/runner/work/cogstack-nlp/cogstack-nlp":"/github/workspace" d92650:6e9ad883586e454f8d4c1b5a303cbaf6  "__token__" "" "https://test.pypi.org/legacy/" "dist" "true" "false" "false"
Warning:  It looks like you are trying to use an API token to authenticate in the package index and your token value does not start with "pypi-" as it typically should. This may cause an authentication error. Please verify that you have copied your token properly if such an error occurs.
Warning:  It looks like there are no Python distribution packages to publish in the directory 'dist/'. Please verify that they are in place should you face this problem.
ERROR    InvalidDistribution: Cannot find file (or expand pattern): 'dist/*'    
```