### PR TITLE
Avoid v2 release workflow run in case of v1 release

### DIFF
--- a/.github/workflows/medcat-v2_release.yml
+++ b/.github/workflows/medcat-v2_release.yml
@@ -3,7 +3,7 @@ name: medcat-v2 - Build Python Package
 on:
   push:
     tags:
-      - "medcat/v*"
+      - "medcat/v2*"
 
 permissions:
   contents: write


### PR DESCRIPTION
Otherwise it would also run on v1 release, but fail.
E.g:
https://github.com/CogStack/cogstack-nlp/actions/runs/16905576431/job/47894459863