### PR TITLE
Add test-time version to main workflow when pushing to test PyPI

### DIFF
--- a/.github/workflows/medcat-v1_main.yml
+++ b/.github/workflows/medcat-v1_main.yml
@@ -113,6 +113,7 @@ jobs:
 
       - name: Build a binary wheel and a source tarball
         run: >-
+          SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MEDCAT="1.16.0dev0"
           python -m
           build
           --sdist


### PR DESCRIPTION
Otherwise it fails as it did in:

https://github.com/CogStack/cogstack-nlp/actions/runs/16905538420/job/47896727730