### PR TITLE
CU-8699wc4zb Port offline BERT MetaCAT load to v2

### DIFF
--- a/medcat-v2/medcat/components/addons/meta_cat/meta_cat.py
+++ b/medcat-v2/medcat/components/addons/meta_cat/meta_cat.py
@@ -125,7 +125,7 @@ class MetaCATAddon(AddonComponent):
     def load(self, folder_path: str) -> 'MetaCAT':
         mc_path, tokenizer_folder = self._get_meta_cat_and_tokenizer_paths(
             folder_path)
-        mc = cast(MetaCAT, deserialise(mc_path))
+        mc = cast(MetaCAT, deserialise(mc_path, save_dir_path=folder_path))
         mc.tokenizer = self._load_tokenizer(self.config, tokenizer_folder)
         return mc
 
@@ -308,10 +308,12 @@ class MetaCAT(AbstractSerialisable):
                  tokenizer: Optional[TokenizerWrapperBase] = None,
                  embeddings: Optional[Union[Tensor, numpy.ndarray]] = None,
                  config: Optional[ConfigMetaCAT] = None,
-                 _model_state_dict: Optional[dict[str, Any]] = None) -> None:
+                 _model_state_dict: Optional[dict[str, Any]] = None,
+                 save_dir_path: Optional[str] = None) -> None:
         if config is None:
             config = ConfigMetaCAT()
         self.config = config
+        self.save_dir_path = save_dir_path
         set_all_seeds(config.general.seed)
 
         self.tokenizer = tokenizer
@@ -355,7 +357,7 @@ class MetaCAT(AbstractSerialisable):
         elif config.model.model_name == 'bert':
             from medcat.components.addons.meta_cat.models import (
                 BertForMetaAnnotation)
-            model = BertForMetaAnnotation(config)
+            model = BertForMetaAnnotation(config, self.save_dir_path)
 
             if not config.model.model_freeze_layers:
                 peft_config = LoraConfig(

--- a/medcat-v2/medcat/components/addons/meta_cat/meta_cat.py
+++ b/medcat-v2/medcat/components/addons/meta_cat/meta_cat.py
@@ -150,6 +150,11 @@ class MetaCATAddon(AddonComponent):
             raise MisconfiguredMetaCATException(
                 "Unable to save MetaCAT without a tokenizer")
         self.mc.tokenizer.save(tokenizer_folder)
+        if self.config.model.model_name == 'bert':
+            model_config_save_path = os.path.join(
+                folder_path, 'bert_config.json')
+            self._mc.model.bert_config.to_json_file(  # type: ignore
+                model_config_save_path)
 
     def _init_data_paths(self, base_tokenizer: BaseTokenizer):
         # a dictionary like {category_name: value, ...}

--- a/medcat-v2/medcat/components/addons/meta_cat/models.py
+++ b/medcat-v2/medcat/components/addons/meta_cat/models.py
@@ -98,11 +98,26 @@ class LSTM(nn.Module):
 class BertForMetaAnnotation(nn.Module):
     _keys_to_ignore_on_load_unexpected: list[str] = [r"pooler"]  # type: ignore
 
-    def __init__(self, config: ConfigMetaCAT):
+    def __init__(self, config: ConfigMetaCAT,
+                 save_dir_path: Optional[str] = None):
         super(BertForMetaAnnotation, self).__init__()
-        _bertconfig = AutoConfig.from_pretrained(
-            config.model.model_variant,
-            num_hidden_layers=config.model.num_layers)
+        if save_dir_path:
+            try:
+                _bertconfig = AutoConfig.from_pretrained(
+                    save_dir_path + "/bert_config.json",
+                    num_hidden_layers=config.model.num_layers)
+            except Exception as e:
+                _bertconfig = AutoConfig.from_pretrained(
+                    config.model.model_variant,
+                    num_hidden_layers=config.model.num_layers)
+                logger.info("BERT config not found locally — "
+                            "downloaded successfully from Hugging Face.")
+                raise e
+        else:
+            _bertconfig = AutoConfig.from_pretrained(
+                config.model.model_variant,
+                num_hidden_layers=config.model.num_layers)
+
         if config.model.input_size != _bertconfig.hidden_size:
             logger.warning(
                 "Input size for %s model should be %d, provided input size is "
@@ -110,8 +125,24 @@ class BertForMetaAnnotation(nn.Module):
                 _bertconfig.hidden_size, config.model.input_size,
                 _bertconfig.hidden_size)
 
-        bert = BertModel.from_pretrained(config.model.model_variant,
-                                         config=_bertconfig)
+        try:
+            bert = BertModel.from_pretrained(
+                config.model.model_variant,
+                config=_bertconfig)
+        except Exception as e:
+            bert = BertModel(_bertconfig)
+            if save_dir_path:
+                logger.info(
+                    "Could not load BERT pretrained weights from Hugging Face."
+                    " BERT model was loaded with random weights.\n"
+                    "This will work the weights will be loaded off disk.")
+            else:
+                logger.warning(
+                    "Could not load BERT pretrained weights from Hugging Face."
+                    " BERT model was loaded with random weights.\n"
+                    "DO NOT use this model without loading the model state!",
+                    exc_info=e)
+
         self.config = config
         self.bert = bert
         self.num_labels = config.model.nclasses

--- a/medcat-v2/medcat/components/addons/meta_cat/models.py
+++ b/medcat-v2/medcat/components/addons/meta_cat/models.py
@@ -145,6 +145,7 @@ class BertForMetaAnnotation(nn.Module):
 
         self.config = config
         self.bert = bert
+        self.bert_config = _bertconfig
         self.num_labels = config.model.nclasses
         for param in self.bert.parameters():
             param.requires_grad = not config.model.model_freeze_layers

--- a/medcat-v2/tests/components/addons/meta_cat/test_bert_meta_cat.py
+++ b/medcat-v2/tests/components/addons/meta_cat/test_bert_meta_cat.py
@@ -12,10 +12,12 @@ from .test_meta_cat import FakeTokenizer
 
 
 @contextmanager
-def no_network():
+def assert_tries_network():
     real_socket = socket.socket
+    calls = []
 
     def guard(*args, **kwargs):
+        calls.append((len(args), len(kwargs)))
         raise OSError("Network disabled for test")
 
     socket.socket = guard
@@ -23,6 +25,7 @@ def no_network():
         yield
     finally:
         socket.socket = real_socket
+        assert calls, "No network calls were made during the test"
 
 
 class BERTMetaCATTests(unittest.TestCase):
@@ -50,6 +53,6 @@ class BERTMetaCATTests(unittest.TestCase):
         cls.temp_dir.cleanup()
 
     def test_no_network_load(self):
-        with no_network():
+        with assert_tries_network():
             mc = deserialise(self.mc_save_path)
         self.assertIsInstance(mc, meta_cat.MetaCATAddon)

--- a/medcat-v2/tests/components/addons/meta_cat/test_bert_meta_cat.py
+++ b/medcat-v2/tests/components/addons/meta_cat/test_bert_meta_cat.py
@@ -1,0 +1,55 @@
+import socket
+from contextlib import contextmanager
+
+from medcat.components.addons.meta_cat import meta_cat
+from medcat.storage.serialisers import serialise, deserialise
+
+import unittest
+import tempfile
+import os
+
+from .test_meta_cat import FakeTokenizer
+
+
+@contextmanager
+def no_network():
+    real_socket = socket.socket
+
+    def guard(*args, **kwargs):
+        raise OSError("Network disabled for test")
+
+    socket.socket = guard
+    try:
+        yield
+    finally:
+        socket.socket = real_socket
+
+
+class BERTMetaCATTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cnf = meta_cat.ConfigMetaCAT()
+        cls.cnf.model.model_name = 'bert'
+        cls.cnf.general.vocab_size = 10
+        cls.cnf.model.padding_idx = 5
+        cls.cnf.general.tokenizer_name = 'bert-tokenizer'
+        cls.cnf.model.model_variant = 'prajjwal1/bert-tiny'
+        cls.cnf.general.category_name = 'FAKE_category'
+        cls.cnf.general.category_value2id = {
+            'Future': 0, 'Past': 2, 'Recent': 1}
+        cls.tokenizer = FakeTokenizer()
+        cls.meta_cat = meta_cat.MetaCATAddon.create_new(cls.cnf, cls.tokenizer)
+
+        cls.temp_dir = tempfile.TemporaryDirectory()
+        cls.mc_save_path = os.path.join(cls.temp_dir.name, "bert_meta_cat")
+        serialise('dill', cls.meta_cat, cls.mc_save_path)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.temp_dir.cleanup()
+
+    def test_no_network_load(self):
+        with no_network():
+            mc = deserialise(self.mc_save_path)
+        self.assertIsInstance(mc, meta_cat.MetaCATAddon)

--- a/medcat-v2/tests/components/addons/meta_cat/test_bert_meta_cat.py
+++ b/medcat-v2/tests/components/addons/meta_cat/test_bert_meta_cat.py
@@ -7,6 +7,9 @@ from medcat.storage.serialisers import serialise, deserialise
 import unittest
 import tempfile
 import os
+from functools import partial
+
+import transformers
 
 from .test_meta_cat import FakeTokenizer
 
@@ -26,6 +29,22 @@ def assert_tries_network():
     finally:
         socket.socket = real_socket
         assert calls, "No network calls were made during the test"
+
+
+# NOTE: need to disable the usage of the cache
+#       otherwise other parts of the test suite
+#       might have already downloaded and cached
+#       the model and no network calls may be made
+#       in such a situation
+@contextmanager
+def force_hf_download():
+    orig_from_pretrained = transformers.BertModel.from_pretrained
+    transformers.BertModel.from_pretrained = partial(
+        orig_from_pretrained, force_download=True)
+    try:
+        yield
+    finally:
+        transformers.BertModel.from_pretrained = orig_from_pretrained
 
 
 class BERTMetaCATTests(unittest.TestCase):
@@ -54,5 +73,6 @@ class BERTMetaCATTests(unittest.TestCase):
 
     def test_no_network_load(self):
         with assert_tries_network():
-            mc = deserialise(self.mc_save_path)
+            with force_hf_download():
+                mc = deserialise(self.mc_save_path)
         self.assertIsInstance(mc, meta_cat.MetaCATAddon)

--- a/medcat-v2/tests/components/addons/meta_cat/test_meta_cat.py
+++ b/medcat-v2/tests/components/addons/meta_cat/test_meta_cat.py
@@ -6,7 +6,10 @@ from medcat.storage.serialisables import Serialisable, ManualSerialisable
 from medcat.storage.serialisers import serialise, AvailableSerialisers
 from medcat.config.config_meta_cat import ConfigMetaCAT
 from medcat.config.config import Config
+from medcat.utils.defaults import COMPONENTS_FOLDER
 
+import os
+import unittest.mock
 import unittest
 import tempfile
 
@@ -103,6 +106,26 @@ class MetaCATWithCATTests(MetaCATBaseTests):
                 temp_dir, serialiser_type=self.SER_TYPE)
             cat2 = CAT.load_model_pack(file_name)
         self.assert_has_meta_cat(cat2, False)
+
+    def test_loading_uses_save_dir_path(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            file_name = self.cat.save_model_pack(
+                temp_dir, serialiser_type=self.SER_TYPE)
+            exp_meta_cat_path = os.path.join(
+                file_name.removesuffix(".zip"),
+                COMPONENTS_FOLDER,
+                self.meta_cat.get_folder_name()
+            )
+            with unittest.mock.patch.object(
+                    meta_cat.MetaCAT, "__init__",
+                    wraps=meta_cat.MetaCAT.__init__,
+                    autospec=True) as mock_load:
+                CAT.load_model_pack(file_name)
+                mock_load.assert_called_once()
+                _, call_kwargs = mock_load.call_args
+                self.assertIn('save_dir_path', call_kwargs)
+                self.assertEqual(
+                    call_kwargs['save_dir_path'], exp_meta_cat_path)
 
     def test_turns_up_in_output(self):
         ents = self.cat.get_entities(


### PR DESCRIPTION
This PR ports the v1 patch (#67) into v2.

On top of that, it also adds a simple test to make sure this actually works. The test disabled network access at test time as well as forces the re-downloading of models (in case another part of the test suite has already downloaded the model - which would have made HF cache the model and no network connection would be needed).