### PR TITLE
bug(medcat-service): Fix DeID mode fails with PydanticSerializationError

### DIFF
--- a/medcat-service/medcat_service/test/test_deid.py
+++ b/medcat-service/medcat_service/test/test_deid.py
@@ -1,4 +1,3 @@
-import logging
 import os
 import unittest
 

--- a/medcat-service/medcat_service/test/test_deid.py
+++ b/medcat-service/medcat_service/test/test_deid.py
@@ -1,10 +1,8 @@
-import os
 import unittest
 
 from fastapi.testclient import TestClient
 
 import medcat_service.test.common as common
-from medcat_service.main import app
 
 
 class TestMedcatServiceDeId(unittest.TestCase):
@@ -22,14 +20,18 @@ class TestMedcatServiceDeId(unittest.TestCase):
     #
     @classmethod
     def setUpClass(cls):
-        common.setup_medcat_processor()
-        os.environ["DEID_MODE"] = "True"
-        os.environ["DEID_REDACT"] = "True"
+        pass
+        # Enable when test enabled. Complexity around env vars being shared accross tests,
+        # Should instead move to use pydantic settings for easy test overrides.
 
-        if "APP_MEDCAT_MODEL_PACK" not in os.environ:
-            os.environ["APP_MEDCAT_MODEL_PACK"] = "./models/example-deid-model-pack.zip"
+        # common.setup_medcat_processor()
+        # os.environ["DEID_MODE"] = "True"
+        # os.environ["DEID_REDACT"] = "True"
 
-        cls.client = TestClient(app)
+        # if "APP_MEDCAT_MODEL_PACK" not in os.environ:
+        #     os.environ["APP_MEDCAT_MODEL_PACK"] = "./models/example-deid-model-pack.zip"
+
+        # cls.client = TestClient(app)
 
     @unittest.skip("Disabled until deid model is committed")
     def testDeidProcess(self):

--- a/medcat-service/medcat_service/test/test_deid.py
+++ b/medcat-service/medcat_service/test/test_deid.py
@@ -1,0 +1,59 @@
+import logging
+import os
+import unittest
+
+from fastapi.testclient import TestClient
+
+import medcat_service.test.common as common
+from medcat_service.main import app
+
+
+class TestMedcatServiceDeId(unittest.TestCase):
+    """
+    Implementation of test cases for MedCAT service
+    """
+
+    # Available endpoints
+    #
+    ENDPOINT_PROCESS_SINGLE = "/api/process"
+    ENDPOINT_PROCESS_BULK = "/api/process_bulk"
+    client: TestClient
+
+    # Static initialization methods
+    #
+    @classmethod
+    def setUpClass(cls):
+        common.setup_medcat_processor()
+        os.environ["DEID_MODE"] = "True"
+        os.environ["DEID_REDACT"] = "True"
+
+        if "APP_MEDCAT_MODEL_PACK" not in os.environ:
+            os.environ["APP_MEDCAT_MODEL_PACK"] = "./models/example-deid-model-pack.zip"
+
+        cls.client = TestClient(app)
+
+    @unittest.skip("Disabled until deid model is committed")
+    def testDeidProcess(self):
+        payload = common.create_payload_content_from_doc_single(
+            "John had been diagnosed with acute Kidney Failure the week before"
+        )
+        response = self.client.post(self.ENDPOINT_PROCESS_SINGLE, json=payload)
+        self.assertEqual(response.status_code, 200)
+
+        actual = response.json()
+
+        expected = {
+            "pretty_name": "PATIENT",
+            "source_value": "John",
+            "cui": "PATIENT",
+            "text": "[****] had been diagnosed with acute Kidney Failure the week before",
+        }
+
+        self.assertEqual(actual["result"]["text"], expected["text"])
+
+        self.assertEqual(len(actual["result"]["annotations"]), 1)
+
+        ann = actual["result"]["annotations"][0]["0"]
+        self.assertEqual(ann["pretty_name"], expected["pretty_name"])
+        self.assertEqual(ann["source_value"], expected["source_value"])
+        self.assertEqual(ann["cui"], expected["cui"])


### PR DESCRIPTION

Used the solution from https://github.com/CogStack/cogstack-nlp/blob/e55bf6cd3fd453c0feafb10f50d33d5732c7ace0/medcat-demo-app/webapp/demo/views.py

I didnt work out why it was returning np.float for DeID mode but not for the regular mode (noting regular just returns 1 in the tests, so could be that). I also didnt work out a better way to make pydantic convert them automatically, seemed like a lot. 

```
INFO:API:Process_result is text='[**********] says hello' annotations=[{0: {'pretty_name': 'PATIENT', 'cui': 'PATIENT', 'type_ids': [], 'source_value': 'John smith', 'detected_name': '', 'acc': np.float32(0.77323574), 'context_similarity': np.float32(0.77323574), 'start': 0, 'end': 10, 'id': 0, 'meta_anns': {}, 'context_left': [], 'context_center': [], 'context_right': []}}] success=True timestamp='2025-08-14T14:06:14.668+00:00' elapsed_time=0.076584845 footer=None
ERROR:API:Unable to process data
Traceback (most recent call last):
  File "/home/ali/workspace/github.com/alhendrickson/CogStack/cogstack-nlp/medcat-service/medcat_service/routers/process.py", line 55, in process
    log.info("Response is " + response.model_dump_json())
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ali/workspace/github.com/alhendrickson/CogStack/cogstack-nlp/medcat-service/.venv/lib/python3.12/site-packages/pydantic/main.py", line 441, in model_dump_json
    return self.__pydantic_serializer__.to_json(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.PydanticSerializationError: Unable to serialize unknown type: <class 'numpy.float32'>
```