### PR TITLE
CU-869a4wpek Trainer qa workflow fix

### DIFF
--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -38,6 +38,9 @@ jobs:
           cd client
           python -m pytest tests/ -v
 
+      - name: Bump version for TestPyPI
+        run: sed -i "s/^version = .*/version = \"1.0.0.dev$(date +%s)\"/" client/pyproject.toml
+
       - name: Build client package
         run: |
           cd client

--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     paths:
       - 'medcat-trainer/**'
+      - '.github/workflows/medcat-trainer_qa.yml'
 
 defaults:
   run:

--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -3,6 +3,9 @@ name: medcat-trainer qa-build
 on:
   push:
     branches: [ main ]
+  pull_request:
+    paths:
+      - 'medcat-trainer/**'
 
 defaults:
   run:

--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -3,10 +3,6 @@ name: medcat-trainer qa-build
 on:
   push:
     branches: [ main ]
-  pull_request:
-    paths:
-      - 'medcat-trainer/**'
-      - '.github/workflows/medcat-trainer_qa.yml'
 
 defaults:
   run:


### PR DESCRIPTION
Attempting to fix the trainer QA workflow.

I _think_ this was just an issue of it trying to push the same version (1.0.0) over and over again. And that was just failing because the test PyPI rejected the duplicate.

EDIT:
Also made the workflow run at PR time so I can check without a merge.