### PR TITLE
Allow 0-patch version if / when a release candidate or beta exists

### DIFF
--- a/medcat-v2/.release/prepare_patch_release.sh
+++ b/medcat-v2/.release/prepare_patch_release.sh
@@ -57,7 +57,12 @@ RELEASE_BRANCH="medcat/v$VERSION_MAJOR_MINOR"
 
 # some prerequisites
 if [[ "$VERSION_PATCH" == "$VERSION_PATCH_AND_PRERELEASE" ]]; then
-    [[ "$VERSION_PATCH" == "0" ]] && error_exit "Patch version must not be 0."
+    if [[ "$VERSION_PATCH" == "0" ]]; then
+        # look for any prerelease tags on this major.minor
+        if ! git tag -l "medcat/v${VERSION_MAJOR_MINOR}.0[a-z]*" | grep -q .; then
+            error_exit "Patch version must not be 0 unless a prerelease (alpha/beta/rc) already exists."
+        fi
+    fi
 fi
 
 run_or_echo git fetch origin


### PR DESCRIPTION
This PR will fix the issue with the current scripts that's preventing a v2.0.0 release as a "patch release" becuase it ends with a `.0` patch release.

Though the setup is designed to treat anything on the existing `medcat/v<major>.<minor>` branch as a previous release on the same minor version. So it _should_ still work with the patch version as 0 if there was previously a beta (or alpha, or release candidate) release.

So the PR will add additional checks to make sure that works as expected.