### PR TITLE
Explicitly specify an empty HF cache during testing of offline load

### DIFF
--- a/medcat-v2/tests/components/addons/meta_cat/test_bert_meta_cat.py
+++ b/medcat-v2/tests/components/addons/meta_cat/test_bert_meta_cat.py
@@ -1,6 +1,5 @@
 import socket
 from contextlib import contextmanager
-import time
 
 from medcat.components.addons.meta_cat import meta_cat
 from medcat.storage.serialisers import serialise, deserialise
@@ -92,7 +91,4 @@ class BERTMetaCATTests(unittest.TestCase):
         with assert_tries_network():
             with force_hf_download():
                 mc = deserialise(self.mc_save_path)
-                # NOTE: the network calls are done async
-                #       and as such we may need to wait for them
-                #       to be done before we exit the context managers,
         self.assertIsInstance(mc, meta_cat.MetaCATAddon)


### PR DESCRIPTION
Seems like the test introduced by the offline BERT MetaCAT load (#85) seems to be failing on (some) subsequent PRs.
Examples of failure:
https://github.com/CogStack/cogstack-nlp/actions/runs/17092576831/job/48478029082

The workflow seems to have run fine on the PR and subsequently upon merge. So perhaps the change is due to the changes in the dependabot PR that includes updating the actions? Perhaps the (new versions of the) actions use a more comprehensive caching system accross multiple runners? I.e something that downloads on one runner and uses the cached version on the other, regardless of me forcing the download through the API?

In any case, I wanted the test to make sure that the offline loading does in fact work. And in order to do that I need to make sure the cache isn't used. So this PR tried to force that behaviour.

EDIT:
Found another failure:
https://github.com/CogStack/cogstack-nlp/actions/runs/17092444219/job/48469017414
So clearly not (only) to do with the dependabot PR.
