### PR TITLE
Fix trainer v1 QA workflow

### DIFF
--- a/.github/workflows/medcat-trainer-v1_qa.yml
+++ b/.github/workflows/medcat-trainer-v1_qa.yml
@@ -12,7 +12,6 @@ jobs:
   # Build and test webapp container
   build-and-push:
     runs-on: ubuntu-latest
-    needs: test-client
     steps:
       - name: Checkout main
         uses: actions/checkout@v4


### PR DESCRIPTION
This was an oversight in #103 where it still needed the job that was removed. And because of that the workflow would fail to run (e.g https://github.com/CogStack/cogstack-nlp/actions/runs/17099268212).

