### PR TITLE
CU-869a6w9c7 Fix stats on 0 prec and 0 rec

### DIFF
--- a/medcat-v2/medcat/stats/stats.py
+++ b/medcat-v2/medcat/stats/stats.py
@@ -239,15 +239,15 @@ class StatsBuilder:
         """
         try:
             if self.tp + self.fp == 0:
-                prec = 0
+                prec = 0.0
             else:
                 prec = self.tp / (self.tp + self.fp)
             if self.tp + self.fp == 0:
-                rec = 0
+                rec = 0.0
             else:
                 rec = self.tp / (self.tp + self.fn)
             if prec == 0 and rec == 0:
-                f1 = 0
+                f1 = 0.0
             else:
                 f1 = 2 * (prec * rec) / (prec + rec)
             if do_print:


### PR DESCRIPTION
If recall and precision are 0, then there's division by 0 for F1 calculation and `get_stats` fails.

So this PR fixes that.

Along the same lines, also added a workaround for when calculating precison and recall would have caused a zero divsion error.