### PR TITLE
CU-869a3ycrj Trusted publisher for PyPI

### DIFF
--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -50,9 +50,8 @@ jobs:
           python -m build
 
       - name: Publish dev distribution to Test PyPI
-        uses: pypa/gh-action-pypi-publish@v1.12.4
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          password: ${{ secrets.MEDCAT_TRAINER_TEST_PYPI_API_TOKEN }}
           repository_url: https://test.pypi.org/legacy/
           packages_dir: medcat-trainer/client/dist
 

--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ main ]
 
+permissions:
+  id-token: write
+
 defaults:
   run:
     working-directory: ./medcat-trainer

--- a/.github/workflows/medcat-trainer_qa.yml
+++ b/.github/workflows/medcat-trainer_qa.yml
@@ -2,7 +2,7 @@ name: medcat-trainer qa-build
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, "CU-869a3ycrj-trusted-publisher" ]
 
 permissions:
   id-token: write


### PR DESCRIPTION
This PR adds trusted publisher based releases to PyPI:
- [x] medcat-trainer QA to TestPyPI
- [ ] medcat-trainer full release to PyPI


PS:
Currently makes the workflow run on pushes to this branch to test it out, this will be removed.