### PR TITLE
CU-869a95nu1 Fix spacy model cleanup

### DIFF
--- a/medcat-v2/medcat/tokenizing/spacy_impl/tokenizers.py
+++ b/medcat-v2/medcat/tokenizing/spacy_impl/tokenizers.py
@@ -108,10 +108,7 @@ class SpacyTokenizer(BaseTokenizer):
             # NOTE: always overwrite
             shutil.rmtree(subfolder)
         logger.debug("Saving spacy model to '%s'", subfolder)
-        cur_path = self._nlp._path
-        if cur_path is None:
-            raise ValueError(f"Unable to save spacy: {self._nlp}")
-        shutil.copytree(cur_path, subfolder)
+        self._nlp.to_disk(subfolder)
         return subfolder
 
     def load_internals_from(self, folder_path: str) -> bool:

--- a/medcat-v2/medcat/tokenizing/spacy_impl/tokenizers.py
+++ b/medcat-v2/medcat/tokenizing/spacy_impl/tokenizers.py
@@ -106,7 +106,7 @@ class SpacyTokenizer(BaseTokenizer):
             folder_path, f"{TOKENIZER_PREFIX}{self._spacy_model_name}")
         if os.path.exists(subfolder):
             # NOTE: always overwrite
-            shutil.rmtree(folder_path)
+            shutil.rmtree(subfolder)
         logger.debug("Saving spacy model to '%s'", subfolder)
         cur_path = self._nlp._path
         if cur_path is None:


### PR DESCRIPTION
There was an error where the cleanup would instead delete the entire folder instead of just the spacy model folder (if it existed before).


This PR also somewaht simplifies the saving of the spacy model.