### PR TITLE
CU-869a9mten Improve duplicate name imports

### DIFF
--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -22,7 +22,7 @@ from medcat.storage.serialisables import AbstractSerialisable
 from medcat.storage.mp_ents_save import BatchAnnotationSaver
 from medcat.utils.fileutils import ensure_folder_if_parent
 from medcat.utils.hasher import Hasher
-from medcat.pipeline.pipeline import Pipeline
+from medcat.pipeline import Pipeline
 from medcat.tokenizing.tokens import MutableDocument, MutableEntity
 from medcat.tokenizing.tokenizers import SaveableTokenizer, TOKENIZER_PREFIX
 from medcat.data.entities import Entity, Entities, OnlyCUIEntities

--- a/medcat-v2/medcat/config/__init__.py
+++ b/medcat-v2/medcat/config/__init__.py
@@ -1,3 +1,9 @@
-from .config import Config
+from .config import (
+    Config, Ner, CDBMaker, Linking, LinkingFilters, ModelMeta,
+    TrainingDescriptor, Components, AnnotationOutput, Preprocessing,
+    UsageMonitor, NLPConfig)
 
-__all__ = ['Config', ]
+__all__ = [
+    'Config', 'Ner', 'CDBMaker', 'Linking', 'LinkingFilters', 'ModelMeta',
+    'TrainingDescriptor', 'Components', 'AnnotationOutput', 'Preprocessing',
+    'UsageMonitor', 'NLPConfig']

--- a/medcat-v2/medcat/model_creation/cdb_maker.py
+++ b/medcat-v2/medcat/model_creation/cdb_maker.py
@@ -5,7 +5,7 @@ import logging
 import re
 from typing import Optional, Union, Any
 
-from medcat.pipeline.pipeline import Pipeline
+from medcat.pipeline import Pipeline
 from medcat.cdb import CDB
 from medcat.config import Config
 from medcat.preprocessors.cleaners import prepare_name

--- a/medcat-v2/medcat/pipeline/__init__.py
+++ b/medcat-v2/medcat/pipeline/__init__.py
@@ -1,0 +1,4 @@
+from .pipeline import Pipeline
+
+
+__all__ = ['Pipeline']

--- a/medcat-v2/medcat/stats/__init__.py
+++ b/medcat-v2/medcat/stats/__init__.py
@@ -1,0 +1,5 @@
+from .stats import get_stats
+from .kfold import get_k_fold_stats
+
+
+__all__ = ['get_stats', 'get_k_fold_stats']

--- a/medcat-v2/medcat/trainer.py
+++ b/medcat-v2/medcat/trainer.py
@@ -16,7 +16,7 @@ from medcat.data.mctexport import (
 from medcat.preprocessors.cleaners import prepare_name, NameDescriptor
 from medcat.components.types import CoreComponentType, TrainableComponent
 from medcat.components.addons.addons import AddonComponent
-from medcat.pipeline.pipeline import Pipeline
+from medcat.pipeline import Pipeline
 
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Improving some imports like `from medcat.pipeline.pipeline import Pipeline` and `from medcat.stats.stats import get_stats`.
And a few more slight simplfications (e.g with `medcat.config` package).