### PR TITLE
Medcat conversion model name hotfix

### DIFF
--- a/medcat-v2/medcat/utils/legacy/conversion_all.py
+++ b/medcat-v2/medcat/utils/legacy/conversion_all.py
@@ -35,6 +35,8 @@ class Converter:
                 medcat1_model_pack_path)[1].rsplit(".zip", 1)[0]
             unpack(medcat1_model_pack_path, folder_path)
             medcat1_model_pack_path = folder_path
+        else:
+            self.old_model_name = os.path.split(medcat1_model_pack_path)[1]
         if not os.path.isdir(medcat1_model_pack_path):
             raise ValueError(
                 "Provided model path is not a directory: "

--- a/medcat-v2/medcat/utils/legacy/conversion_all.py
+++ b/medcat-v2/medcat/utils/legacy/conversion_all.py
@@ -31,7 +31,8 @@ class Converter:
                  ser_type: AvailableSerialisers = AvailableSerialisers.dill):
         if medcat1_model_pack_path.endswith(".zip"):
             folder_path = medcat1_model_pack_path[:-4]
-            self.old_model_name = os.path.split(medcat1_model_pack_path)[1]
+            self.old_model_name = os.path.split(
+                medcat1_model_pack_path)[1].rsplit(".zip", 1)[0]
             unpack(medcat1_model_pack_path, folder_path)
             medcat1_model_pack_path = folder_path
         if not os.path.isdir(medcat1_model_pack_path):


### PR DESCRIPTION
This fixes 2 small issues with converted model names:
- If it's a `.zip`, the previous implementation would leave teh `.zip` in the middle of the new name
  - That's because the save mechanism adds the hash and extension (unless otherwise specified)
- If it's a folder, the converter would fail
  - Because the `old_model_name` attribute wasn't set

EDIT: This is an extension of #118 