### PR TITLE
docs: Add a pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+## What does this change do?
+<!-- A brief summary of the change -->
+
+
+<!-- Why is this change needed? For example, what is the current behaviour, compared to the new behavior.  -->
+
+
+## How was this tested?
+<!-- How did you verify the change works as expected? How can reviewers repeat those tests? -->
+
+
+## Other details
+<!-- If the implementation is complex, add details here. Also include any other related issues, docs, or discussions -->
+
+
+<!--## Is there a breaking change introduced? -->
+<!-- Is there a breaking change in this PR? Will existing users have to modify anything in order to keep running?  -->
+
+
+<!-- 
+## Checklist
+- [ ] The PR title and commit messages includes the type of change described in [the contributing guidelines](https://github.com/CogStack/cogstack-nlp/blob/main/CONTRIBUTING.md)
+- [ ] The relevant checks have all passed
+- [ ] Tests added/updated if applicable
+ -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,10 +122,8 @@ An example PR title could be
 feat(medcat-service): Create API for healthchecks for container monitoring
 ```
 
-#### Pull Request Bodies
-We haven't put a formal template in for pull requests yet.
-
-Though the structure isn’t enforced, a good PR description helps reviewers and future maintainers.
+#### Pull Request Description
+A good PR description helps reviewers and future maintainers.
 
 Consider including things such as:
 


### PR DESCRIPTION
## What does this change do?
<!-- A brief summary of the change -->
I've added a PR template, mainly as it seems easier than documenting it. I kind of want to try things out, and change it over time instead of trying to perfect it.

Right now I've got it with comments, but maybe empty titles is actually better. 

I kind of want to avoid it being too formal like this one https://[raw.githubusercontent.com/angular/angular/refs/heads/main/.github/PULL_REQUEST_TEMPLATE.md](https://raw.githubusercontent.com/angular/angular/refs/heads/main/.github/PULL_REQUEST_TEMPLATE.md). Most templates seemed aimed at new/rare users, instead of prioritising the maintenance team


<!-- Why is this change needed? For example, what is the current behaviour, compared to the new behavior.  -->


## How was this tested?
<!-- How did you verify the change works as expected? How can reviewers repeat those tests? -->
NA

## Other details
<!-- If the implementation is complex, add details here. Also include any other related issues, docs, or discussions -->
NA

<!--## Is there a breaking change introduced? -->
<!-- Is there a breaking change in this PR? Will existing users have to modify anything in order to keep running?  -->


<!-- 
## Checklist
- [ ] The PR title and commit messages includes the type of change described in [the contributing guidelines](https://github.com/CogStack/cogstack-nlp/blob/main/CONTRIBUTING.md)
- [ ] The relevant checks have all passed
- [ ] Tests added/updated if applicable
 -->