### PR TITLE
CU-869ahw0mw: Add argument to control data flow when saving results.

### DIFF
--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -331,7 +331,9 @@ class CAT(AbstractSerialisable):
             entity_consume_mode_on_save: Union[
                 Literal["save"], Literal["save_and_return"],
                 Literal["lazy"]] = "save",
-            ) -> Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
+            ) -> Union[
+                Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]],
+                list[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]]:
         """Get entities from multiple texts (potentially in parallel).
 
         If `n_process` > 1, `n_process - 1` new processes will be created
@@ -387,8 +389,10 @@ class CAT(AbstractSerialisable):
                     caller to drive the iteration.
 
         Yields:
-            Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
-                The results in the format of (text_index, entities).
+            Union[
+                Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]],
+                list[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]]:
+                    The results in the format of (text_index, entities).
         """
         text_iter = cast(
             Union[Iterator[str], Iterator[tuple[str, str]]], iter(texts))
@@ -405,14 +409,17 @@ class CAT(AbstractSerialisable):
                 # this materialises the iterator and forces the
                 # output to be saved on disk, nothing is yielded
                 deque(out_iter, maxlen=0)
+                return []
             elif entity_consume_mode_on_save == "lazy":
                 # do the lazy iteration - force the user to drive iteration
-                yield from out_iter
+                return out_iter
             else:
-                # force materialising of output to save on disk
+                # force materialising of output to save on dis
                 out_list = list(out_iter)
                 # but yield from the list as well
-                yield from out_list
+                return out_list
+        else:
+            return out_iter
 
     def _get_entities_multi_texts(
             self,

--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -319,6 +319,57 @@ class CAT(AbstractSerialisable):
             # Yield all results from this batch
             yield from cur_results
 
+    def save_entities_multi_texts(
+            self,
+            texts: Union[Iterable[str], Iterable[tuple[str, str]]],
+            save_dir_path: str,
+            only_cui: bool = False,
+            n_process: int = 1,
+            batch_size: int = -1,
+            batch_size_chars: int = 1_000_000,
+            batches_per_save: int = 20,
+    ) -> None:
+        """Saves the resulting entities on disk and allows multiprocessing.
+
+        This uses `get_entities_multi_texts` under the hood. But it is designed
+        to save the data on disk as it comes through.
+
+        Args:
+            texts (Union[Iterable[str], Iterable[tuple[str, str]]]):
+                The input text. Either an iterable of raw text or one
+                with in the format of `(text_index, text)`.
+            save_dir_path (str):
+                The path where the results are saved. The directory will have
+                a `annotated_ids.pickle` file containing the
+                `tuple[list[str], int]` with a list of indices already saved
+                and the number of parts already saved. In addition there will
+                be (usually multuple) files in the `part_<num>.pickle` format
+                with the partial outputs.
+            only_cui (bool):
+                Whether to only return CUIs rather than other information
+                like start/end and annotated value. Defaults to False.
+            n_process (int):
+                Number of processes to use. Defaults to 1.
+                The number of texts to batch at a time. A batch of the
+                specified size will be given to each worker process.
+                Defaults to -1 and in this case the character count will
+                be used instead.
+            batch_size_chars (int):
+                The maximum number of characters to process in a batch.
+                Each process will be given batch of texts with a total
+                number of characters not exceeding this value. Defaults
+                to 1,000,000 characters. Set to -1 to disable.
+        """
+        if save_dir_path is None:
+            raise ValueError("Need to specify a save path (`save_dir_path`), "
+                             f"got {save_dir_path}")
+        out_iter = self.get_entities_multi_texts(
+            texts, only_cui=only_cui, n_process=n_process,
+            batch_size=batch_size, batch_size_chars=batch_size_chars,
+            save_dir_path=save_dir_path, batches_per_save=batches_per_save)
+        # NOTE: not keeping anything since it'll be saved on disk
+        deque(out_iter, maxlen=0)
+
     def get_entities_multi_texts(
             self,
             texts: Union[Iterable[str], Iterable[tuple[str, str]]],
@@ -328,12 +379,7 @@ class CAT(AbstractSerialisable):
             batch_size_chars: int = 1_000_000,
             save_dir_path: Optional[str] = None,
             batches_per_save: int = 20,
-            entity_consume_mode_on_save: Union[
-                Literal["save"], Literal["save_and_return"],
-                Literal["lazy"]] = "save",
-            ) -> Union[
-                Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]],
-                list[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]]:
+            ) -> Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
         """Get entities from multiple texts (potentially in parallel).
 
         If `n_process` > 1, `n_process - 1` new processes will be created
@@ -369,30 +415,10 @@ class CAT(AbstractSerialisable):
             batches_per_save (int):
                 The number of patches to save (if `save_dir_path` is specified)
                 at once. Defaults to 20.
-            entity_consume_mode_on_save (Union[
-                    Literal["save"], Literal["save_and_return"],
-                    Literal["lazy"]]):
-                Controls how results are handled when `save_dir_path` is
-                provided:
-                - "save":
-                    Iterate through results internally, writing them to disk.
-                    Nothing is yielded/returned. This avoids storing all
-                    results in memory and is suitable for large data sets.
-                - "save_and_return":
-                    As above, but also return a fully materialised list of all
-                    results. **Warning**: this may require large amounts of
-                    memory and is not safe for large amounts of data.
-                - "lazy":
-                    Do not consume results internally. Results are both
-                    yielded and written to disk as the caller iterates over
-                    them. This preserves lazy evaluation but requires the
-                    caller to drive the iteration.
 
         Yields:
-            Union[
-                Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]],
-                list[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]]:
-                    The results in the format of (text_index, entities).
+            Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
+                The results in the format of (text_index, entities).
         """
         text_iter = cast(
             Union[Iterator[str], Iterator[tuple[str, str]]], iter(texts))
@@ -402,24 +428,8 @@ class CAT(AbstractSerialisable):
             saver = BatchAnnotationSaver(save_dir_path, batches_per_save)
         else:
             saver = None
-        out_iter = self._get_entities_multi_texts(
+        yield from self._get_entities_multi_texts(
             n_process=n_process, batch_iter=batch_iter, saver=saver)
-        if saver:
-            if entity_consume_mode_on_save == "save":
-                # this materialises the iterator and forces the
-                # output to be saved on disk, nothing is yielded
-                deque(out_iter, maxlen=0)
-                return []
-            elif entity_consume_mode_on_save == "lazy":
-                # do the lazy iteration - force the user to drive iteration
-                return out_iter
-            else:
-                # force materialising of output to save on dis
-                out_list = list(out_iter)
-                # but yield from the list as well
-                return out_list
-        else:
-            return out_iter
 
     def _get_entities_multi_texts(
             self,

--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -6,6 +6,7 @@ from datetime import date
 from concurrent.futures import ProcessPoolExecutor, as_completed, Future
 import itertools
 from contextlib import contextmanager
+from collections import deque
 
 import shutil
 import zipfile
@@ -327,6 +328,9 @@ class CAT(AbstractSerialisable):
             batch_size_chars: int = 1_000_000,
             save_dir_path: Optional[str] = None,
             batches_per_save: int = 20,
+            entity_consume_mode_on_save: Union[
+                Literal["save"], Literal["save_and_return"],
+                Literal["lazy"]] = "save",
             ) -> Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
         """Get entities from multiple texts (potentially in parallel).
 
@@ -363,6 +367,24 @@ class CAT(AbstractSerialisable):
             batches_per_save (int):
                 The number of patches to save (if `save_dir_path` is specified)
                 at once. Defaults to 20.
+            entity_consume_mode_on_save (Union[
+                    Literal["save"], Literal["save_and_return"],
+                    Literal["lazy"]]):
+                Controls how results are handled when `save_dir_path` is
+                provided:
+                - "save":
+                    Iterate through results internally, writing them to disk.
+                    Nothing is yielded/returned. This avoids storing all
+                    results in memory and is suitable for large data sets.
+                - "save_and_return":
+                    As above, but also return a fully materialised list of all
+                    results. **Warning**: this may require large amounts of
+                    memory and is not safe for large amounts of data.
+                - "lazy":
+                    Do not consume results internally. Results are both
+                    yielded and written to disk as the caller iterates over
+                    them. This preserves lazy evaluation but requires the
+                    caller to drive the iteration.
 
         Yields:
             Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
@@ -376,6 +398,28 @@ class CAT(AbstractSerialisable):
             saver = BatchAnnotationSaver(save_dir_path, batches_per_save)
         else:
             saver = None
+        out_iter = self._get_entities_multi_texts(
+            n_process=n_process, batch_iter=batch_iter, saver=saver)
+        if saver:
+            if entity_consume_mode_on_save == "save":
+                # this materialises the iterator and forces the
+                # output to be saved on disk, nothing is yielded
+                deque(out_iter, maxlen=0)
+            elif entity_consume_mode_on_save == "lazy":
+                # do the lazy iteration - force the user to drive iteration
+                yield from out_iter
+            else:
+                # force materialising of output to save on disk
+                out_list = list(out_iter)
+                # but yield from the list as well
+                yield from out_list
+
+    def _get_entities_multi_texts(
+            self,
+            n_process: int,
+            batch_iter: Iterator[list[tuple[str, str, bool]]],
+            saver: Optional[BatchAnnotationSaver],
+            ) -> Iterator[tuple[str, Union[dict, Entities, OnlyCUIEntities]]]:
         if n_process == 1:
             # just do in series
             for batch in batch_iter:

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -658,6 +658,47 @@ class CATWithDictNERSupTrainingTests(CATSupTrainingTests):
             self.assert_correct_loaded_output(
                 in_data, out_dict_all, all_loaded_output)
 
+    def test_get_entities_multi_texts_with_save_dir_lazy(self):
+        texts = ["text1", "text2"]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            out = self.cat.get_entities_multi_texts(
+                texts,
+                save_dir_path=tmp_dir,
+                entity_consume_mode_on_save='lazy')
+            # nothing before manual iter
+            self.assertFalse(os.listdir(tmp_dir))
+            out_list = list(out)
+            # something was saved
+            self.assertTrue(os.listdir(tmp_dir))
+            # and something was yielded
+            self.assertEqual(len(out_list), len(texts))
+
+    def test_get_entities_multi_texts_with_save_dir_save(self):
+        texts = ["text1", "text2"]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            out = self.cat.get_entities_multi_texts(
+                texts,
+                save_dir_path=tmp_dir,
+                entity_consume_mode_on_save='save')
+            # stuff was already saved
+            self.assertTrue(os.listdir(tmp_dir))
+            out_list = list(out)
+            # nothing was yielded
+            self.assertFalse(out_list)
+
+    def test_get_entities_multi_texts_with_save_dir_save_and_return(self):
+        texts = ["text1", "text2"]
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            out = self.cat.get_entities_multi_texts(
+                texts,
+                save_dir_path=tmp_dir,
+                entity_consume_mode_on_save='save_and_return')
+            # stuff was already saved
+            self.assertTrue(os.listdir(tmp_dir))
+            out_list = list(out)
+            # and something was yielded
+            self.assertEqual(len(out_list), len(texts))
+
 
 class CATWithDocAddonTests(CATIncludingTests):
     EXAMPLE_TEXT = "Example text to tokenize"

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -542,6 +542,7 @@ class CATWithDictNERSupTrainingTests(CATSupTrainingTests):
             n_process=n_process,
             entity_consume_mode_on_save='lazy'
             )
+        out_data = list(out_data)
         out_dict_all = {
             key: cdata for key, cdata in out_data
         }

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -534,13 +534,13 @@ class CATWithDictNERSupTrainingTests(CATSupTrainingTests):
             for name in self.cdb.name2info
             for negname in self.cdb.name2info if name != negname
         ]
-        out_data = list(self.cat.get_entities_multi_texts(
+        out_data = self.cat.get_entities_multi_texts(
             in_data,
             save_dir_path=save_to,
             batch_size_chars=chars_per_batch,
             batches_per_save=batches_per_save,
             n_process=n_process,
-            ))
+            )
         out_dict_all = {
             key: cdata for key, cdata in out_data
         }

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -540,7 +540,6 @@ class CATWithDictNERSupTrainingTests(CATSupTrainingTests):
             batch_size_chars=chars_per_batch,
             batches_per_save=batches_per_save,
             n_process=n_process,
-            entity_consume_mode_on_save='lazy'
             )
         out_data = list(out_data)
         out_dict_all = {
@@ -665,8 +664,7 @@ class CATWithDictNERSupTrainingTests(CATSupTrainingTests):
         with tempfile.TemporaryDirectory() as tmp_dir:
             out = self.cat.get_entities_multi_texts(
                 texts,
-                save_dir_path=tmp_dir,
-                entity_consume_mode_on_save='lazy')
+                save_dir_path=tmp_dir)
             # nothing before manual iter
             self.assertFalse(os.listdir(tmp_dir))
             out_list = list(out)
@@ -675,31 +673,14 @@ class CATWithDictNERSupTrainingTests(CATSupTrainingTests):
             # and something was yielded
             self.assertEqual(len(out_list), len(texts))
 
-    def test_get_entities_multi_texts_with_save_dir_save(self):
+    def test_save_entities_multi_texts(self):
         texts = ["text1", "text2"]
         with tempfile.TemporaryDirectory() as tmp_dir:
-            out = self.cat.get_entities_multi_texts(
+            self.cat.save_entities_multi_texts(
                 texts,
-                save_dir_path=tmp_dir,
-                entity_consume_mode_on_save='save')
+                save_dir_path=tmp_dir)
             # stuff was already saved
             self.assertTrue(os.listdir(tmp_dir))
-            out_list = list(out)
-            # nothing was yielded
-            self.assertFalse(out_list)
-
-    def test_get_entities_multi_texts_with_save_dir_save_and_return(self):
-        texts = ["text1", "text2"]
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            out = self.cat.get_entities_multi_texts(
-                texts,
-                save_dir_path=tmp_dir,
-                entity_consume_mode_on_save='save_and_return')
-            # stuff was already saved
-            self.assertTrue(os.listdir(tmp_dir))
-            out_list = list(out)
-            # and something was yielded
-            self.assertEqual(len(out_list), len(texts))
 
 
 class CATWithDocAddonTests(CATIncludingTests):

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -540,6 +540,7 @@ class CATWithDictNERSupTrainingTests(CATSupTrainingTests):
             batch_size_chars=chars_per_batch,
             batches_per_save=batches_per_save,
             n_process=n_process,
+            entity_consume_mode_on_save='lazy'
             )
         out_dict_all = {
             key: cdata for key, cdata in out_data

--- a/medcat-v2/tests/utils/ner/test_deid.py
+++ b/medcat-v2/tests/utils/ner/test_deid.py
@@ -213,14 +213,15 @@ class DeIDModelWorks(unittest.TestCase):
         self.assert_deid_redact(anon_text)
 
     def test_model_works_deid_multi_text_single_threaded(self):
-        processed = self.deid_model.deid_multi_texts([input_text, input_text], n_process=1)
+        processed = self.deid_model.deid_multi_texts([input_text, input_text],
+                                                     n_process=1)
         self.assertEqual(len(processed), 2)
         for anon_text in processed:
             self.assert_deid_annotations(anon_text)
 
     def test_model_works_deid_multi_text_single_threaded_redact(self):
         processed = self.deid_model.deid_multi_texts([input_text, input_text],
-                                                    n_process=1, redact=True)
+                                                     n_process=1, redact=True)
         self.assertEqual(len(processed), 2)
         for anon_text in processed:
             self.assert_deid_redact(anon_text)

--- a/medcat-v2/tests/utils/ner/test_deid.py
+++ b/medcat-v2/tests/utils/ner/test_deid.py
@@ -213,13 +213,13 @@ class DeIDModelWorks(unittest.TestCase):
         self.assert_deid_redact(anon_text)
 
     def test_model_works_deid_multi_text_single_threaded(self):
-        processed = self.deid_model.deid_multi_text([input_text, input_text], n_process=1)
+        processed = self.deid_model.deid_multi_texts([input_text, input_text], n_process=1)
         self.assertEqual(len(processed), 2)
         for anon_text in processed:
             self.assert_deid_annotations(anon_text)
 
     def test_model_works_deid_multi_text_single_threaded_redact(self):
-        processed = self.deid_model.deid_multi_text([input_text, input_text],
+        processed = self.deid_model.deid_multi_texts([input_text, input_text],
                                                     n_process=1, redact=True)
         self.assertEqual(len(processed), 2)
         for anon_text in processed:
@@ -229,7 +229,7 @@ class DeIDModelWorks(unittest.TestCase):
     @unittest.skip("Deid Multiprocess is broken. Exits the process, no errors shown")
     def test_model_can_multiprocess_no_redact(self):
 
-        processed = self.deid_model.deid_multi_text(
+        processed = self.deid_model.deid_multi_texts(
             [input_text, input_text], n_process=2)
         self.assertEqual(len(processed), 2)
         for tid, new_text in enumerate(processed):
@@ -245,7 +245,7 @@ class DeIDModelWorks(unittest.TestCase):
          """
         try:
             print("Calling test_model_can_multiprocess_redact")
-            processed = self.deid_model.deid_multi_text(
+            processed = self.deid_model.deid_multi_texts(
                 [input_text, input_text], n_process=2, redact=True
             )
             print("Finished processing")


### PR DESCRIPTION
When  is provided, the user (probably) expects the data to be saved on disk upon method call. But the current implementation forced the user to iterate over the results to force the annotation to actually happen.

~~So this change allows the method to materialise the list internally to force the annotation to happen and results to be saved on disk. Additionally, it adds 2 other options:~~
1. ~~The lazy iteration (what happens when no  is provided) where the iteration of data is left to the user~~
2. ~~The combined / saved and return option where the results are materialised, but also yielded. Notably, this will take up a lot of memory if/when used with large data sets~~

Instead of the above, the current version of the PR introduces a new method:
`CAT.save_entities_multi_texts` that:
a) requires a `save_dir_path`
b) always saves data on disk
c) never returns anything

The save + return option is still (kind of) available with `get_entities_multi_texts`, but it still requires manual iteration over the result.

This appraoch separates this concern into a separate method and makes the `get_entities_multi_texts` method less complex.