### PR TITLE
docs (medcat-den): Fix homepage and repo links in pyproject.toml

### DIFF
--- a/medcat-den/pyproject.toml
+++ b/medcat-den/pyproject.toml
@@ -45,9 +45,9 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/CogStack/medcat-den"
-Repository = "https://github.com/CogStack/medcat-den"
-Issues = "https://github.com/CogStack/medcat-den/issues"
+Homepage = "https://github.com/CogStack/cogstack-nlp/tree/main/medcat-den"
+Repository = "https://github.com/CogStack/cogstack-nlp/tree/main/medcat-den"
+Issues = "https://github.com/CogStack/cogstack-nlp/issues"
 
 [tool.setuptools_scm]
 root = ".."


### PR DESCRIPTION
The repo links were incorrect - they pointed to the old privat repo. And as such the links on PyPI were also incorrect.

This PR fixes them.