### PR TITLE
CU-869aupp8v: Remove python 3.9 support

### DIFF
--- a/.github/workflows/medcat-den_main.yml
+++ b/.github/workflows/medcat-den_main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
       max-parallel: 4
     steps:
       - uses: actions/checkout@v5
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/medcat-den_release.yml
+++ b/.github/workflows/medcat-den_release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.10'
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/medcat-v1_main.yml
+++ b/.github/workflows/medcat-v1_main.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
       max-parallel: 4
 
     steps:
@@ -93,10 +93,10 @@ jobs:
           ref: 'main'
           fetch-depth: 0
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Install pypa/build
         run: >-

--- a/.github/workflows/medcat-v1_production.yml
+++ b/.github/workflows/medcat-v1_production.yml
@@ -29,10 +29,10 @@ jobs:
           ref: ${{ github.event.release.target_commitish }}
           fetch-depth: 0
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Run UATs
         run: |

--- a/.github/workflows/medcat-v2_main.yml
+++ b/.github/workflows/medcat-v2_main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
       max-parallel: 4
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/medcat-v2_release.yml
+++ b/.github/workflows/medcat-v2_release.yml
@@ -50,10 +50,10 @@ jobs:
           git pull origin $BRANCH_NAME
 
         # NOTE: building with the lowest python version supported by the package
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install build dependencies
         run: pip install --upgrade build
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -90,25 +90,10 @@ jobs:
 
       - name: Generate requirements and download (CPU)
         run: |
-          if [[ "${{ matrix.python-version }}" == "3.9" ]]; then
-            echo "Runnoing unsafe index strategy for Python 3.9 to avoid issues with torch / numpy compatibility"
-            # NOTE: for python 3.9 it will otherwise look for `numpy>2` in torch's index
-            #       but there's (as of writing on 2025-07-02) none there that support 3.9
-            #       (though there are ones that support 3.10+) and because of that this
-            #       step would fail wihtout the unsafe index match
-            #       for some documentation on dependency confusion attacks, can reference:
-            #       https://docs.astral.sh/uv/reference/settings/#pip_index-strategy
-            uv pip compile pyproject.toml --only-binary=:all: \
-              --extra spacy --extra deid --extra meta-cat --extra rel-cat \
-              --extra-index-url https://download.pytorch.org/whl/cpu \
-              --index-strategy unsafe-best-match \
-              > req-cpu.txt
-          else
-            uv pip compile pyproject.toml --only-binary=:all: \
+          uv pip compile pyproject.toml --only-binary=:all: \
               --extra spacy --extra deid --extra meta-cat --extra rel-cat \
               --extra-index-url https://download.pytorch.org/whl/cpu \
               > req-cpu.txt
-          fi
           uv venv .venv
           .venv/bin/python -m ensurepip
           .venv/bin/python -m pip download --only-binary=:all: --dest bundle-cpu -r req-cpu.txt --extra-index-url https://download.pytorch.org/whl/cpu

--- a/medcat-den/pyproject.toml
+++ b/medcat-den/pyproject.toml
@@ -11,7 +11,7 @@ license = { text = "Apache-2.0" }
 authors = [
     { name="Mart Ratas", email="mart.ratas@kcl.ac.uk" }
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 keywords = ["NLP", "medical", "MedCAT", "model-registry"]
 
@@ -20,7 +20,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",

--- a/medcat-v2/docs/main.md
+++ b/medcat-v2/docs/main.md
@@ -41,7 +41,7 @@ Some guides on how to use MedCAT v2 are available at [MedCAT Tutorials](https://
 - [MedCATtrainer](https://github.com/CogStack/cogstack-nlp/tree/main/medcat-trainer/) - an interface for building, improving and customising a given Named Entity Recognition and Linking (NER+L) model (MedCAT) for biomedical domain text.
 - [MedCATservice](https://github.com/CogStack/cogstack-nlp/blob/main/medcat-service/) - implements the MedCAT NLP application as a service behind a REST API.
 
-## Install using PIP (Requires Python 3.9+)
+## Install using PIP (Requires Python 3.10+)
 Installation instructions are to follow upon a release of this version on PyPI.
 Though installation is likely to be simply `pip install "medcat>=2.0"` at that time.
 Currently the installation for the 2.0 beta release is simply:

--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -7,7 +7,7 @@ description = "Medical Concept Annotation Toolkit (v2)"
 
 readme = "README.md"
 
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 license = "Apache-2.0"
 
@@ -42,7 +42,6 @@ classifiers = [
   # that you indicate you support Python 3. These classifiers are *not*
   # checked by "pip install". See instead "python_requires" below.
   "Programming Language :: Python :: 3",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -85,7 +84,6 @@ dev = [
 ]
 spacy = [
   "spacy",
-  "spacy<3.8.4; python_version == '3.9'"
 ]
 meta_cat = [
   "transformers>=4.41.0,<5.0", # avoid major bump


### PR DESCRIPTION
Python 3.9 will be end of life after October 2025. So we're almost there now.

Therefore, suggesting dropping support for 3.9.

Notably new syntax this would unlock for the library:
- The `|` type hints (e.g `MyType | None` instead of `Optional[None]`; or `str | float` instead of `Union[str, float]`)
- Pattern matching with `match` and `case`
