### PR TITLE
bug (medcat-v1): CU-869auqcd2 Fix MedCAT v1 workflow

### DIFF
--- a/v1/medcat-tutorials/requirements-dev.txt
+++ b/v1/medcat-tutorials/requirements-dev.txt
@@ -8,3 +8,4 @@ jinja2<=3.0
 matplotlib>=3.4.0,<3.8.0
 seaborn
 ipython<9.0.0
+ipykernel<7.0


### PR DESCRIPTION
This PR fixes MedCAT v1 tutorials workflow. 

They are failing because a major update to `ipykernel` is causing some kind of stall. So the PR pins `ipykernel<7` to fix the issue.