### PR TITLE
build(medcat-den): CU-869auqkgc Fix duplicates in TestPyPI publish

### DIFF
--- a/.github/workflows/medcat-den_main.yml
+++ b/.github/workflows/medcat-den_main.yml
@@ -72,6 +72,11 @@ jobs:
         run: |
           python -m build
 
+      - name: Set timestamp-based dev version
+        run: |
+          TS=$(date -u +"%Y%m%d%H%M%S")
+          echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MEDCAT_DEN=0.2.2.dev${TS}" >> $GITHUB_ENV
+
       - name: Publish distribution to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:


### PR DESCRIPTION
This PR changes local scheme for version in order to try and fix duplicate versions being pushed to TestPyPI.

The underlying issue was that if there were 2 PRs that are the same "distance" (i.e commits) from the last tag / release, they would produce the same version when pushing to TestPyPI. The first one would be fine, but the next one would be rejected as a duplicate.

I think the fix will end up being timestamping for the specific version when publishing to TestPyPI.