### PR TITLE
feat (MedCAT): CU-869auz1ck Add a bulk CUI removal method for the CDB

### DIFF
--- a/medcat-v2/medcat/cdb/cdb.py
+++ b/medcat-v2/medcat/cdb/cdb.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Any, Collection, Union, Literal
+from typing import Iterable, Any, Collection, Union, Literal, Sequence
 import os
 
 from medcat.storage.serialisables import AbstractSerialisable
@@ -354,16 +354,14 @@ class CDB(AbstractSerialisable):
         self._reset_subnames()
         self.is_dirty = True
 
-    def remove_cui(self, cui: str) -> None:
-        """This function takes a CUI and removes it the CDB.
+    def remove_cuis_bulk(self, cuis: Sequence[str]) -> None:
+        for cui in cuis:
+            self._remove_cui(cui)
+        # reset subnames once
+        self._reset_subnames()
 
-        It also removes the CUI from name specific per_cui_status
-        maps as well as well as removes all the names that do not
-        correspond to any CUIs after the removal of this one.
-
-        Args:
-            cui (str): The CUI to remove.
-        """
+    def _remove_cui(self, cui: str) -> None:
+        # NOTE: remove CUI without doing a subname reset
         if cui not in self.cui2info:
             logger.warning(
                 "Trying remove CUI '%s' which does not exist in CDB", cui)
@@ -375,6 +373,18 @@ class CDB(AbstractSerialisable):
             # if name name corresponds to no CUIs
             if not ni['per_cui_status']:
                 del self.name2info[name]
+
+    def remove_cui(self, cui: str) -> None:
+        """This function takes a CUI and removes it the CDB.
+
+        It also removes the CUI from name specific per_cui_status
+        maps as well as well as removes all the names that do not
+        correspond to any CUIs after the removal of this one.
+
+        Args:
+            cui (str): The CUI to remove.
+        """
+        self._remove_cui(cui)
         # need to reset subnames
         self._reset_subnames()
         self.is_dirty = True


### PR DESCRIPTION
When trying to remove a bunch of CUIs at once, the `CDB.remove_cui` method is quite slow because it's resetting the subnames every time.

The issue is that there's nothing mapping subnames to the CUIs so at removal of a CUI the model can't tell whether / which subnames need to be removed. As such, they're regenerated from scratch every time.

This PR adds a `CDB.remove_cuis_bulk` method that calls `_reset_subnames` once instead.