### PR TITLE
build(medcat-den): Fix duplicate push versions to TestPyPI

### DIFF
--- a/.github/workflows/medcat-den_main.yml
+++ b/.github/workflows/medcat-den_main.yml
@@ -68,14 +68,14 @@ jobs:
         run: |
           pip install -e .
 
-      - name: Build package
-        run: |
-          python -m build
-
       - name: Set timestamp-based dev version
         run: |
           TS=$(date -u +"%Y%m%d%H%M%S")
           echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MEDCAT_DEN=0.2.2.dev${TS}" >> $GITHUB_ENV
+
+      - name: Build package
+        run: |
+          python -m build
 
       - name: Publish distribution to TestPyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Set pretend version with timesamp before build for den.

PR #174 was supposed to fix that, but the setting of the pretend version was after building so it didn't take effect at the right time.

This PR should fix that.