### PR TITLE
CU-869awf45h: Update patch release script for more flexibility.

### DIFF
--- a/medcat-v2/.release/prepare_patch_release.sh
+++ b/medcat-v2/.release/prepare_patch_release.sh
@@ -117,8 +117,22 @@ if $DRY_RUN; then
     git checkout "$ORIGINAL_REF" >/dev/null 2>&1 || error_exit "Could not return to original branch"
 fi
 
+# Validate cherry-pick hashes
+if [[ ${#CHERRYPICK_HASHES[@]} -eq 0 ]]; then
+    echo "EMPTY"
+    # Allow empty list only if this is a .0 release and a prerelease exists
+    if [[ "$VERSION_PATCH" == "0" ]]; then
+        if ! git tag -l "medcat/v${VERSION_MAJOR_MINOR}.0[a-z]*" | grep -q .; then
+            error_exit "No cherry-pick hashes provided for $VERSION — expected at least one unless this is a .0 release after a pre-release."
+        fi
+    else
+        error_exit "No cherry-pick hashes provided for $VERSION — expected at least one for patch releases."
+    fi
+fi
+
+
 # do the cherry-picking
-for HASH in "${CHERRYPICK_HASHES[@]}"; do
+for HASH in "${CHERRYPICK_HASHES[@]-}"; do
     if ! run_or_echo git cherry-pick "$HASH"; then
         echo "Conflict detected when cherry-picking $HASH."
         echo


### PR DESCRIPTION
This will allow a minor release after a pre-release to be pushed out without any cherry-picked cahnges. Normally, with a patch release, you would expect to cherry-pick at least something, but with a pre-release that is being spun out as a full release, that's not always the case.

So this PR will allow no cherry-picks only if the version being created is a minor release after a pre-release for said minor release.

PS: The naming of the 2 release scripts isn't great. The prepare_patch_release.sh script is designed to deal with anything that already had a release within the same minor release cycle (i.e 2.2.1 after 2.2.0, but also 2.2.0 after 2.2.0a1 or 2.2.0rc1).