### PR TITLE
CU-869ag3k8a: Avoid using protected attribute for pipe getting

### DIFF
--- a/medcat-v2-tutorials/notebooks/introductory/meta/1._Add_a_MetaCat_to_a_Model.ipynb
+++ b/medcat-v2-tutorials/notebooks/introductory/meta/1._Add_a_MetaCat_to_a_Model.ipynb
@@ -156,7 +156,7 @@
     "# create MetaCAT\n",
     "# TODO: remove need for call to protected attribute\n",
     "mc = MetaCATAddon.create_new(\n",
-    "    config, cat._pipeline.tokenizer,\n",
+    "    config, cat.pipe.tokenizer,\n",
     "    tknzer_preprocessor=lambda tknzer: tknzer.hf_tokenizers.train(data_path))\n",
     "\n",
     "# add MetaCAT\n",
@@ -166,7 +166,7 @@
     "else:\n",
     "    cat.add_addon(mc)\n",
     "print(\"Addon configs:\", cat.config.components.addons)\n",
-    "print(\"Addons\", cat._pipeline._addons)"
+    "print(\"Addons\", cat.get_addons())"
    ]
   },
   {


### PR DESCRIPTION
Small PR to avoid using protected (`_`-prefixed) attributes for getting pipe (or other activities).