### PR TITLE
CU-869awnz6y: Allow both halves of v1 tests to run in a 45 minute window

### DIFF
--- a/.github/workflows/medcat-v1_main.yml
+++ b/.github/workflows/medcat-v1_main.yml
@@ -51,8 +51,9 @@ jobs:
           midpoint=$((num_files / 2))
           first_half_nl=$(echo "$all_files" | head -n $midpoint)
           second_half_nl=$(echo "$all_files" | tail -n +$(($midpoint + 1)))
-          timeout 25m python -m unittest ${first_half_nl[@]}
-          timeout 25m python -m unittest ${second_half_nl[@]}
+          python -m unittest ${first_half_nl[@]}
+          python -m unittest ${second_half_nl[@]}
+        timeout-minutes: 45m
       - name: Regression
         run: source tests/resources/regression/run_regression.sh
       - name: Model backwards compatibility


### PR DESCRIPTION
They would normally (i.e last successful run) run for a total of around 25 minutes. And the first half would take around 23.5 minutes. Looks like the first half is now taking more than 25 minutes, which makes it fail. However, the 2nd half seems to take only around 1 minute (53 seconds in last successful run), so the total doesn't need to be that high.

Refer to e.g:
https://github.com/CogStack/cogstack-nlp/actions/runs/18654060573/job/53178675003#step:8:7429

And last succesful:
https://github.com/CogStack/cogstack-nlp/actions/runs/18593658908/job/53014320971