### PR TITLE
build(medcat): CU-869awp33n Rename typod workflow file name

### DIFF
--- a/.github/workflows/medcat-v2-lib-stability.yml
+++ b/.github/workflows/medcat-v2-lib-stability.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:     # allow manual runs
   pull_request:
     paths:
-      - ".github/workflows/medcat-v2-lib-stabiliy.yml"
+      - ".github/workflows/medcat-v2-lib-stability.yml"
 
 defaults:
   run:


### PR DESCRIPTION
The file name had a typo (`stabiliy` instead of `stability`). So renamed and had it refer to itself for changes correctly as well.