### PR TITLE
build(medcat-den): CU-869awy4ux Set pretend version before installation of package.

### DIFF
--- a/.github/workflows/medcat-den_main.yml
+++ b/.github/workflows/medcat-den_main.yml
@@ -64,14 +64,14 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install --upgrade build
 
-      - name: Install package in development mode
-        run: |
-          pip install -e .
-
       - name: Set timestamp-based dev version
         run: |
           TS=$(date -u +"%Y%m%d%H%M%S")
           echo "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MEDCAT_DEN=0.2.2.dev${TS}" >> $GITHUB_ENV
+
+      - name: Install package in development mode
+        run: |
+          pip install -e .
 
       - name: Build package
         run: |


### PR DESCRIPTION
This should fix the installation picking up (and trying to infer a version) from tags unrelated to medcat-den.

Currently, the workflow is picking up trainer's medcat-trainer/v3.1.0 tag and getting confused since that does not work for the regex (which expected medcat-den/v*). And as such, the workflow is failing. See for example: https://github.com/CogStack/cogstack-nlp/actions/runs/18660829454/job/53200931476