### PR TITLE
CU-869azvxkn: Remove duplicate lines for transformers dependency.

### DIFF
--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -89,8 +89,6 @@ spacy = [
 ]
 meta_cat = [
   "transformers>=4.41.0,<5.0", # avoid major bump
-  # Transformers 4.57 doesn't support 3.9
-  "transformers!=4.57.0; python_version == '3.9'",
   "peft>0.8.2,<1.0",
   "torch>=2.4.0,<3.0",
   "scikit-learn>=1.1.3,<2.0",
@@ -104,8 +102,6 @@ dict_ner = [
 deid = [
   "datasets>=2.2.2,<3.0.0",
   "transformers>=4.41.0,<5.0", # avoid major bump
-  # Transformers 4.57 doesn't support 3.9
-  "transformers!=4.57.0; python_version == '3.9'",
   "scikit-learn>=1.1.3,<2.0",
   "torch>=2.4.0,<3.0",
   # since 3.13 we need to use later version of scipy for it
@@ -114,8 +110,6 @@ deid = [
 ]
 rel_cat = [
   "transformers>=4.41.0,<5.0", # avoid major bump
-  # Transformers 4.57 doesn't support 3.9
-  "transformers!=4.57.0; python_version == '3.9'",
   "scikit-learn>=1.1.3,<2.0",
   "torch>=2.4.0,<3.0",
 ]


### PR DESCRIPTION
Looks like both #167 and #171 added these lines and they now appeared duplicated in pyproject.toml. This PR removes the duplicates.