### PR TITLE
fix(medcat): CU-869azdc7x: Dynamic imports for legacy conversion (#198)

### DIFF
--- a/medcat-v2/medcat/utils/legacy/conversion_all.py
+++ b/medcat-v2/medcat/utils/legacy/conversion_all.py
@@ -118,7 +118,7 @@ class Converter:
             from medcat.utils.legacy.convert_deid import get_trf_ner_from_old
             trf_ners = [
                 get_trf_ner_from_old(subfolder, cat.pipe.tokenizer)
-                for subfolder in os.listdir(self.old_model_folder)
+                for subfolder in trf_folders
             ]
             if len(trf_ners) > 1:
                 raise ValueError("Cannot use more than 1 tranformers NER. "


### PR DESCRIPTION
Fixes missing variable use causing a crash using a v1 deid model

## Previous behavior
Crash on model load:

```shell fold
cogstack-medcat-service-production  | 2025-10-29 12:07:51,162 [INFO] MedCatProcessor: Initializing MedCAT processor ...
cogstack-medcat-service-production  | 2025-10-29 12:07:51,300 [INFO] MedCatProcessor: Torch autograd disabled (inference mode only)
cogstack-medcat-service-production  | 2025-10-29 12:07:51,304 [INFO] MedCatProcessor: Torch threads set to 8
cogstack-medcat-service-production  | 2025-10-29 12:07:51,304 [INFO] MedCatProcessor: Loading model pack...
cogstack-medcat-service-production  | Doing legacy conversion on CAT (at '/cat/models/De-ID_UCLH_Fine-tuned'). Set the environment variable MEDCAT_AVOID_LECACY_CONVERSION to `True` to avoid this.
cogstack-medcat-service-production  | Missing class medcat.config.weighted_average, replacing with LegacyClassNotFound.
cogstack-medcat-service-production  | Trying to set 'weighted_average_function' for 'Linking' but no such attribute
cogstack-medcat-service-production  | 2025-10-29 12:07:54,355 [ACCESS] - 172.20.0.1:46094 - "POST /api/process HTTP/1.1" 500 Internal Server Error
cogstack-medcat-service-production  | Exception in ASGI application
cogstack-medcat-service-production  | Traceback (most recent call last):
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/uvicorn/protocols/http/httptools_impl.py", line 409, in run_asgi
cogstack-medcat-service-production  |     result = await app(  # type: ignore[func-returns-value]
cogstack-medcat-service-production  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/uvicorn/middleware/proxy_headers.py", line 60, in __call__
cogstack-medcat-service-production  |     return await self.app(scope, receive, send)
cogstack-medcat-service-production  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/fastapi/applications.py", line 1054, in __call__
cogstack-medcat-service-production  |     await super().__call__(scope, receive, send)
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/applications.py", line 113, in __call__
cogstack-medcat-service-production  |     await self.middleware_stack(scope, receive, send)
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 187, in __call__
cogstack-medcat-service-production  |     raise exc
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/errors.py", line 165, in __call__
cogstack-medcat-service-production  |     await self.app(scope, receive, _send)
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/middleware/exceptions.py", line 62, in __call__
cogstack-medcat-service-production  |     await wrap_app_handling_exceptions(self.app, conn)(scope, receive, send)
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 62, in wrapped_app
cogstack-medcat-service-production  |     raise exc
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 51, in wrapped_app
cogstack-medcat-service-production  |     await app(scope, receive, sender)
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 715, in __call__
cogstack-medcat-service-production  |     await self.middleware_stack(scope, receive, send)
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 735, in app
cogstack-medcat-service-production  |     await route.handle(scope, receive, send)
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 288, in handle
cogstack-medcat-service-production  |     await self.app(scope, receive, send)
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 76, in app
cogstack-medcat-service-production  |     await wrap_app_handling_exceptions(app, request)(scope, receive, send)
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 62, in wrapped_app
cogstack-medcat-service-production  |     raise exc
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/_exception_handler.py", line 51, in wrapped_app
cogstack-medcat-service-production  |     await app(scope, receive, sender)
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/routing.py", line 73, in app
cogstack-medcat-service-production  |     response = await f(request)
cogstack-medcat-service-production  |                ^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", line 291, in app
cogstack-medcat-service-production  |     solved_result = await solve_dependencies(
cogstack-medcat-service-production  |                     ^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/fastapi/dependencies/utils.py", line 632, in solve_dependencies
cogstack-medcat-service-production  |     solved = await run_in_threadpool(call, **solved_result.values)
cogstack-medcat-service-production  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/starlette/concurrency.py", line 39, in run_in_threadpool
cogstack-medcat-service-production  |     return await anyio.to_thread.run_sync(func, *args)
cogstack-medcat-service-production  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/anyio/to_thread.py", line 56, in run_sync
cogstack-medcat-service-production  |     return await get_async_backend().run_sync_in_worker_thread(
cogstack-medcat-service-production  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 2485, in run_sync_in_worker_thread
cogstack-medcat-service-production  |     return await future
cogstack-medcat-service-production  |            ^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/usr/local/lib/python3.11/site-packages/anyio/_backends/_asyncio.py", line 976, in run
cogstack-medcat-service-production  |     result = context.run(func, *args)
cogstack-medcat-service-production  |              ^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/cat/medcat_service/dependencies.py", line 37, in get_medcat_processor
cogstack-medcat-service-production  |     return get_medcat_processor_singleton(settings)
cogstack-medcat-service-production  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/cat/medcat_service/dependencies.py", line 30, in get_medcat_processor_singleton
cogstack-medcat-service-production  |     _def_medcat_processor = (settings, MedCatProcessor(settings))
cogstack-medcat-service-production  |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/cat/medcat_service/nlp_processor/medcat_processor.py", line 67, in __init__
cogstack-medcat-service-production  |     self.cat: DeIdModel | CAT = self._create_cat()
cogstack-medcat-service-production  |                                 ^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/cat/medcat_service/nlp_processor/medcat_processor.py", line 288, in _create_cat
cogstack-medcat-service-production  |     cat = DeIdModel.load_model_pack(self.service_settings.medcat_model_pack)
cogstack-medcat-service-production  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/cat/medcat-v2/medcat/components/ner/trf/deid.py", line 150, in load_model_pack
cogstack-medcat-service-production  |     ner_model = NerModel.load_model_pack(model_pack_path, config=config)
cogstack-medcat-service-production  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/cat/medcat-v2/medcat/components/ner/trf/model.py", line 160, in load_model_pack
cogstack-medcat-service-production  |     cat = CAT.load_model_pack(model_pack_path)  # , ner_config_dict=config)
cogstack-medcat-service-production  |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/cat/medcat-v2/medcat/cat.py", line 812, in load_model_pack
cogstack-medcat-service-production  |     return Converter(model_pack_path, None).convert()
cogstack-medcat-service-production  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/cat/medcat-v2/medcat/utils/legacy/conversion_all.py", line 119, in convert
cogstack-medcat-service-production  |     trf_ners = [
cogstack-medcat-service-production  |                ^
cogstack-medcat-service-production  |   File "/cat/medcat-v2/medcat/utils/legacy/conversion_all.py", line 120, in <listcomp>
cogstack-medcat-service-production  |     get_trf_ner_from_old(subfolder, cat.pipe.tokenizer)
cogstack-medcat-service-production  |   File "/cat/medcat-v2/medcat/utils/legacy/convert_deid.py", line 26, in get_trf_ner_from_old
cogstack-medcat-service-production  |     config = get_cnf(os.path.join(old_path, exp_cat_config_name))
cogstack-medcat-service-production  |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
cogstack-medcat-service-production  |   File "/cat/medcat-v2/medcat/utils/legacy/convert_deid.py", line 18, in get_cnf
cogstack-medcat-service-production  |     with open(cnf_path) as f:
cogstack-medcat-service-production  |          ^^^^^^^^^^^^^^
cogstack-medcat-service-production  | FileNotFoundError: [Errno 2] No such file or directory: 'model_card.json/cat_config.json'
```

## New behavior

```

cogstack-medcat-service-production  | 2025-10-29 12:12:44,709 [INFO] MedCatProcessor: Initializing MedCAT processor ...
cogstack-medcat-service-production  | 2025-10-29 12:12:44,794 [INFO] MedCatProcessor: Torch autograd disabled (inference mode only)
cogstack-medcat-service-production  | 2025-10-29 12:12:44,796 [INFO] MedCatProcessor: Torch threads set to 8
cogstack-medcat-service-production  | 2025-10-29 12:12:44,796 [INFO] MedCatProcessor: Loading model pack...
cogstack-medcat-service-production  | Doing legacy conversion on CAT (at '/cat/models/De-ID_UCLH_Fine-tuned'). Set the environment variable MEDCAT_AVOID_LECACY_CONVERSION to `True` to avoid this.
cogstack-medcat-service-production  | Missing class medcat.config.weighted_average, replacing with LegacyClassNotFound.
cogstack-medcat-service-production  | Trying to set 'weighted_average_function' for 'Linking' but no such attribute
cogstack-medcat-service-production  | Missing class medcat.config.weighted_average, replacing with LegacyClassNotFound.
cogstack-medcat-service-production  | Trying to set 'weighted_average_function' for 'Linking' but no such attribute
cogstack-medcat-service-production  | Using the `WANDB_DISABLED` environment variable is deprecated and will be removed in v5. Use the --report_to flag to control the integrations used for logging result (for instance --report_to none).
cogstack-medcat-service-production  | Device set to use cpu
cogstack-medcat-service-production  | 2025-10-29 12:12:50,654 [INFO] MedCatProcessor: MedCAT processor is ready
cogstack-medcat-service-production  | 2025-10-29 12:12:50,807 [ACCESS] - 172.20.0.1:49638 - "POST /api/process HTTP/1.1" 200 OK
```