### PR TITLE
feat(medcat-service): Add optional metrics instrumentation with prometheus

### DIFF
--- a/medcat-service/README.md
+++ b/medcat-service/README.md
@@ -328,6 +328,7 @@ The following environment variables are available for tailoring the MedCAT Servi
 - `APP_MODEL_META_PATH_LIST` - the list of paths to meta-annotation models, each separated by `:` character (optional),
 - `APP_BULK_NPROC` - the number of threads used in bulk processing (default: `8`),
 - `APP_MEDCAT_MODEL_PACK` -  MedCAT Model Pack path, if this parameter has a value IT WILL BE LOADED FIRST OVER EVERYTHING ELSE (CDB, Vocab, MetaCATs, etc.) declared above.
+- `APP_ENABLE_METRICS` - Enable prometheus metrics collection served on the path /metrics
 
 ### Shared Memory (`DOCKER_SHM_SIZE`)
 

--- a/medcat-service/medcat_service/main.py
+++ b/medcat-service/medcat_service/main.py
@@ -36,6 +36,11 @@ app.include_router(process.router)
 
 gr.mount_gradio_app(app, io, path="/demo")
 
+if settings.observability.enable_metrics:
+    from prometheus_fastapi_instrumentator import Instrumentator
+
+    Instrumentator(excluded_handlers=["/api/health.*", "/metrics"],).instrument(app).expose(app, tags=["admin"])
+
 
 @app.exception_handler(HealthCheckFailedException)
 async def healthcheck_failed_exception_handler(request: Request, exc: HealthCheckFailedException):
@@ -45,6 +50,7 @@ async def healthcheck_failed_exception_handler(request: Request, exc: HealthChec
 if __name__ == "__main__":
     # Only run this when directly executing `python main.py` for local dev.
     import os
+
     import uvicorn
 
     uvicorn.run("medcat_service.main:app", host="0.0.0.0", port=int(os.environ.get("SERVER_PORT", 8000)))


### PR DESCRIPTION
Add prometheus metrics for collection on a `/metrics` API. Reasoning is I want to know requests per second, and average request duration across N instances of the service

## Usage
Toggle on or off without the env variable

```
2025-10-29 13:42:15,144 [ACCESS] - 127.0.0.1:51960 - "GET /metrics HTTP/1.1" 404 Not Found
```

```
export APP_ENABLE_PROMETHEUS=true

2025-10-29 13:43:16,278 [ACCESS] - 127.0.0.1:54424 - "GET /metrics HTTP/1.1" 200 OK
```

Metrics can then be collected and shown in grafana, for example: 

<img width="1447" height="526" alt="image" src="https://github.com/user-attachments/assets/977ae3d2-65c6-4b64-a35d-dd1464e1b3b0" />
