### PR TITLE
build(medcat-service): CU-869b2zjay Clean runner to free up space for docker builds

### DIFF
--- a/.github/workflows/medcat-service_docker.yml
+++ b/.github/workflows/medcat-service_docker.yml
@@ -104,13 +104,6 @@ jobs:
           build-args: |
             REINSTALL_CORE_FROM_LOCAL=true
 
-      - name: Clean Docker to free up space
-        # NOTE: otherwise the runner tends to run out of disk space roughly 75% of the time
-        run: |
-          df -h # Optional: Check space before build
-          docker system prune -af
-          df -h # Optional: Check space before build
-
       - name: Build and push Docker Jupyter singleuser image with GPU support
         id: docker_build_gpu
         uses: docker/build-push-action@v6


### PR DESCRIPTION
Previously, a lot of the times the workflow fails the first couple of times due to running out of disk space. For instance, this one only succeeded on the 4th attempt:
https://github.com/CogStack/cogstack-nlp/actions/runs/19104323916

The specific failure reads:
```
build
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251105-143106-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id)
   at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message)
   at GitHub.Runner.Worker.Worker.RunAsync(String pipeIn, String pipeOut)
   at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251105-143106-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at GitHub.Runner.Common.HostTraceListener.WriteHeader(String source, TraceEventType eventType, Int32 id)
   at System.Diagnostics.TraceSource.TraceEvent(TraceEventType eventType, Int32 id, String message)
   at GitHub.Runner.Common.Tracing.Error(Exception exception)
   at GitHub.Runner.Worker.Program.MainAsync(IHostContext context, String[] args)
Unhandled exception. System.IO.IOException: No space left on device : '/home/runner/actions-runner/cached/_diag/Worker_20251105-143106-utc.log'
   at System.IO.RandomAccess.WriteAtOffset(SafeFileHandle handle, ReadOnlySpan`1 buffer, Int64 fileOffset)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.Diagnostics.TextWriterTraceListener.Flush()
   at System.Diagnostics.TraceSource.Flush()
   at GitHub.Runner.Common.Tracing.Dispose(Boolean disposing)
   at GitHub.Runner.Common.Tracing.Dispose()
   at GitHub.Runner.Common.TraceManager.Dispose(Boolean disposing)
   at GitHub.Runner.Common.TraceManager.Dispose()
   at GitHub.Runner.Common.HostContext.Dispose(Boolean disposing)
   at GitHub.Runner.Common.HostContext.Dispose()
   at GitHub.Runner.Worker.Program.Main(String[] args)
```

This generally happened in the "Build and push Docker Jupyter singleuser image with GPU support" step.

This PR will attempt to rectify that by:
- ~~Cleaning up docker before GPU build step~~
  - ~~This should remove a bunch of the files docker wrote on disk to avoid the issue with running out of disk space in the next step~~
  - ~~The entire (successful) workflow job previously took less than 4 minutes~~
    - ~~So the small slowdown due to pruning the cache is unlikely to be significant~~
- Cleans up the worker state before it starts
  - To remove a bunch of unnecessary packages / tools
  - Seems to give around 16GB of extra space on disk