### PR TITLE
CU-869b6nm32: Clean up container before building docker conatiner.

### DIFF
--- a/.github/workflows/medcat-demo-app_build.yml
+++ b/.github/workflows/medcat-demo-app_build.yml
@@ -21,6 +21,19 @@ jobs:
     steps:
     - uses: actions/checkout@v5
 
+    - name: 🧹 Free up disk space
+      run: |
+        df -h # Optional: Check space before build
+        # Remove large, unnecessary packages/tools
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/share/swift
+        sudo rm -rf /usr/share/rust
+        sudo rm -rf /usr/share/powershell
+        # Remove cached tools and files
+        sudo apt-get clean
+        df -h # Optional: Check space before build
+
     - name: Set up Docker Compose
       run: sudo apt-get update && sudo apt-get install -y docker-compose
 


### PR DESCRIPTION
This is identical to the issue / fix in https://github.com/CogStack/cogstack-nlp/pull/216.

Example failure on main branch merge:
https://github.com/CogStack/cogstack-nlp/actions/runs/19426780957/attempts/1