### PR TITLE
CU-869b75fhg: Fix issue with actual DeID in anon cat demo.

### DIFF
--- a/anoncat-demo-app/app/anoncat/views.py
+++ b/anoncat-demo-app/app/anoncat/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import render
-from medcat.cat import CAT
+from medcat.utils.ner.deid import DeIdModel as CAT
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
 
@@ -23,7 +23,7 @@ def deidentify(request):
 
     input_text = request.data['text']
     redact = request.data['redact']
-    output_text = deid_text(cat, input_text, redact=redact)
+    output_text = cat.deid_text(input_text, redact=redact)
 
     # Save the form data to the DeidentifiedText model
     text = DeidentifiedText()


### PR DESCRIPTION
The deid_text method in medcat.utils.ner was deprecated in favour of using the  instead. However, the change in #223 removed the import (probably because otherwise it failed due to an import error) without replacing it with the new alteranative. This PR fixes that.