### PR TITLE
feat(medcat-plugins) trainable linker for the embedding linker

### DIFF
--- a/.github/workflows/medcat-embedding-linker_ci.yml
+++ b/.github/workflows/medcat-embedding-linker_ci.yml
@@ -7,7 +7,7 @@ on:
       - 'medcat-embedding-linker/v*.*.*'  
   pull_request:
     paths:
-      - 'medcat-embedding-linker/**'
+      - 'medcat-plugins/medcat-embedding-linker/**'
       - '.github/workflows/medcat-embedding-linker**'
 
 permissions:

--- a/medcat-plugins/embedding-linker/README.md
+++ b/medcat-plugins/embedding-linker/README.md
@@ -28,19 +28,21 @@ pip install medcat-embedding-linker
 
 ## Quick Start
 
+### Replacing current linker with a static embedding linker
+
 ```python
 from medcat.cat import CAT
 from medcat.config import Config
 from medcat.components.types import CoreComponentType
-
-from medcat_embedding_linker import EmbeddingLinking
+from medcat_embedding_linker.embedding_linker import Linker as StaticEmbeddingLinker
+from medcat_embedding_linker.config import EmbeddingLinking
 
 # Load your MedCAT model
 cat = CAT.load_model_pack("path/to/model_pack")
 
 # Configure the embedding linker
 cat.config.components.linking = EmbeddingLinking()
-cat.config.components.linking.embedding_model_name = "sentence-transformers/all-MiniLM-L6-v2"
+cat.config.components.linking.comp_name = StaticEmbeddingLinker.name
 
 # Recreate the pipeline to register the new linker
 cat._recreate_pipe()
@@ -54,11 +56,52 @@ linker.create_embeddings()
 entities = cat.get_entities("Patient presents with chest pain and dyspnea.")
 ```
 
+### Replacing current linker with a trainable embedding linker AND training
+
+```python
+from medcat.cat import CAT
+from medcat_embedding_linker.trainable_embedding_linker import TrainableEmbeddingLinker
+from medcat_embedding_linker.config import EmbeddingLinking
+
+# Load your MedCAT model
+cat = CAT.load_model_pack("path/to/model_pack")
+
+# Configure the embedding linker
+cat.config.components.linking = EmbeddingLinking()
+cat.config.components.linking.comp_name = TrainableEmbeddingLinker.name
+
+# Recreate the pipeline to register the new linker
+cat._recreate_pipe()
+
+# Generate embeddings for your concept database
+linker = self.get_component(CoreComponentType.linking)
+# create 
+linker.create_embeddings()
+
+# load required data into MedCATTrainerExport format
+train_projects, test_projects = your_dataset_loading_method()
+
+# Training loop - four is probably a nice stopping point
+num_epochs = 4
+
+# the first epoch is done out of the loop incase new concepts / names are detected
+cat.trainer.train_supervised_raw(train_projects, test_size=0, nepochs=1)
+# refreshing the structure here is required for new cuis/names that have been detected
+# so the efficient lookup lists need to be recreated
+linker.refresh_structure()
+linker.create_embeddings()
+get_stats(cat=cat, data=test_projects, use_project_filters=False)
+for i in range(num_epochs - 1):
+    cat.trainer.train_supervised_raw(train_projects, test_size=0, nepochs=1)
+    linker.create_embeddings()
+    get_stats(cat=cat, data=test_projects, use_project_filters=False)
+```
+
 ## How It Works
 
 ### Component Registration
 
-The embedding linker automatically registers itself as `embedding_linker` when `EmbeddingLinking` config is detected. It implements MedCAT's `AbstractEntityProvidingComponent` interface and is lazily loaded when the pipeline is created.
+The embedding linker automatically requires the name of the trainable or static component when `EmbeddingLinking` config is detected. It implements MedCAT's `AbstractEntityProvidingComponent` interface and is lazily loaded when the pipeline is created.
 
 ### Embedding Generation
 
@@ -87,8 +130,7 @@ For each detected entity:
 
 ## Configuration
 
-### Key Parameters
-
+### Key Parameters - Static and Trainable
 ```python
 config.components.linking = EmbeddingLinking(
     # Model settings
@@ -119,6 +161,21 @@ config.components.linking = EmbeddingLinking(
     gpu_device="cuda:0"  # or None for auto-detect
 )
 ```
+### Key Parameters - Trainable ONLY
+
+```python
+config.components.linking = EmbeddingLinking(
+    # Training settings
+    train_on_names: bool = True
+    training_batch_size: int = 32
+    embed_per_n_batches: int = 0
+
+    # Model settings
+    use_mention_attention: bool = True
+    use_projection_layer: bool = True
+    top_n_layers_to_unfreeze: int = 0
+)
+```
 
 ### Embedding Models
 
@@ -127,6 +184,7 @@ Any HuggingFace model compatible with sentence transformers will work. Popular o
 - `sentence-transformers/all-MiniLM-L6-v2` (default, fast and lightweight)
 - `sentence-transformers/all-mpnet-base-v2` (higher quality)
 - `UFNLP/gatortron-medium` (biomedical domain)
+- `abhinand/MedEmbed-small-v0.1` (often the best performing)
 - `microsoft/BiomedNLP-PubMedBERT-base-uncased-abstract-fulltext`
 
 ## Advanced Usage
@@ -171,11 +229,14 @@ cat.config.components.linking.filters.cuis_exclude = {"C0000001"}
 - **GPU recommended**: 10-50x faster inference with CUDA
 - **Batch sizes**: Increase if you have GPU memory available
 - **Model selection**: Smaller models (e.g., MiniLM) are faster but may be less accurate than larger domain-specific models
+- **Unfreezing layers**: The more layers you unfreeze of a model - the better the predictive power of the model _should_ increase. This will come at the cost of increased computation.
+- **Using a projection layer**: This will have no (or a slightly negative) impact on static embeddings. On trainable embeddings this will result in a large performance increase (i.e. 50-75% increase in recall or more). This is always trainable, as that is the point of it. The computational cost is minimal.
+- **Mention Attention**: This will generate embeddings for the tokens of interest based on the sourounding context - not the entire context of detected entity. This should always result in a performance increase, at zero computational cost. The only case where this might not be true is if the entire detected context is all of a detected entity, at which case performance will be exactly equal to not using mention attention.
+- **embed_per_n_batches**: This is how many training batches have been completed before re-embedding all names / cuis. Setting this to 0 means that re-embedding will never occur, and must be done manually. Re-embedding more often can result in a slight performance increase. However this is a long process and should probably be avoided / tested. It's recomended to set this to 0, and re-embed manually every epoch.
 
 ## Limitations
 
 - Does not support `prefer_frequent_concepts` or `prefer_primary_name` from the default linker (logs warnings if set)
-- Training mode is not applicable (logs warning if enabled)
 - Requires pre-computed embeddings before inference
 
 ## Citation

--- a/medcat-plugins/embedding-linker/pyproject.toml
+++ b/medcat-plugins/embedding-linker/pyproject.toml
@@ -55,7 +55,7 @@ classifiers = [
 # For an analysis of this field vs pip's requirements files see:
 # https://packaging.python.org/discussions/install-requires-vs-requirements/
 dependencies = [
-  "medcat[spacy]>=2.5",
+  "medcat[spacy]>=2.7",
   "transformers>=4.41.0,<5.0", # avoid major bump
   "torch>=2.4.0,<3.0",
   "tqdm",

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/config.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/config.py
@@ -1,5 +1,4 @@
 from typing import Optional, Any
-
 from medcat.config import Linking
 
 

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/config.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/config.py
@@ -5,13 +5,39 @@ from medcat.config import Linking
 
 class EmbeddingLinking(Linking):
     """The config exclusively used for the embedding linker"""
+
     comp_name: str = "embedding_linker"
     """Changing compoenent name"""
     filter_before_disamb: bool = False
+    """Training on names or CUIs. If True all names of all CUIs will be used to train. 
+    If false only CUIs preffered (or longest names will be used to train). Training on 
+    names is more expensive computationally (and RAM/VRAM), but can lead to better 
+    performance."""
+    train_on_names: bool = True
     """Filtering CUIs before disambiguation"""
-    train: bool = False
-    """The embedding linker never needs to be trained in its 
-    current implementation."""
+    training_batch_size: int = 32
+    """The size of the batch to be used for training."""
+    embed_per_n_batches: int = 0
+    """How many batches to train on before re-embedding the all names in the context 
+    model. This is used to control how often the context model is updated during 
+    training."""
+    use_similarity_threshold: bool = True
+    """Do we have a similarity threshold we care about?"""
+    negative_sampling_k: int = 10
+    """How many negative samples to generate for each positive sample during 
+    training."""
+    negative_sampling_candidate_pool_size: int = 4096
+    """When generating negative samples, sample top_n candidates to consider when 
+    sampling. Higher numbers will make training slower but can provide varied negative 
+    samples."""
+    negative_sampling_temperature: float = 0.1
+    """Temperature to use when generating negative samples in training. Lower 
+    temperatures will make the sampling more focused on the highest scoring candidates, 
+    while higher temperatures will make it more random. Must be > 0."""
+    use_mention_attention: bool = True
+    """Improves performance and fun to say. Mention attention can help the model focus 
+    on the most relevant parts of the context when making linking decisions. Will only 
+    pool on the tokens that contain the entity mention, with no context."""
     long_similarity_threshold: float = 0.0
     """Used in the inference step to choose the best CUI given the
     link candidates. Testing shows a threshold of 0.7 increases precision
@@ -26,11 +52,16 @@ class EmbeddingLinking(Linking):
     embedding_model_name: str = "sentence-transformers/all-MiniLM-L6-v2"
     """Name of the embedding model. It must be downloadable from 
     huggingface linked from an appropriate file directory"""
+    use_projection_layer: bool = True
+    """Projection-layer default for trainable embedding linker."""
+    top_n_layers_to_unfreeze: int = 0
+    """LM unfreezing default for trainable embedding linker.
+    -1 unfreezes all LM layers, 0 freezes all LM layers, 
+    n unfreezes the top n layers."""
     max_token_length: int = 64
     """Max number of tokens to be embedded from a name.
     If the max token length is changed then the linker will need to be created
-    with a new config.
-    """
+    with a new config."""
     embedding_batch_size: int = 4096
     """How many pieces names can be embedded at once, useful when 
     embedding name2info names, cui2info names"""
@@ -44,5 +75,3 @@ class EmbeddingLinking(Linking):
     use_ner_link_candidates: bool = True
     """Link candidates are provided by some NER steps. This will flag if 
     you want to trust them or not."""
-    use_similarity_threshold: bool = True
-    """Do we have a similarity threshold we care about?"""

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/embedding_linker.py
@@ -4,6 +4,7 @@ from medcat.components.types import CoreComponentType
 from medcat.components.types import AbstractEntityProvidingComponent
 from medcat.tokenizing.tokens import MutableEntity, MutableDocument
 from medcat.tokenizing.tokenizers import BaseTokenizer
+from medcat_embedding_linker.transformer_context_model import ModelForEmbeddingLinking
 from typing import Optional, Iterator, Set
 from medcat.vocab import Vocab
 from medcat.utils.postprocessing import filter_linked_annotations
@@ -205,7 +206,7 @@ class Linker(AbstractEntityProvidingComponent):
         ):
             self.cnf_l.embedding_model_name = embedding_model_name
             self.tokenizer = AutoTokenizer.from_pretrained(embedding_model_name)
-            self.model = AutoModel.from_pretrained(embedding_model_name)
+            self.model = ModelForEmbeddingLinking.from_pretrained(embedding_model_name)
             self.model.eval()
             gpu_device = self.cnf_l.gpu_device
             self.device = torch.device(
@@ -227,10 +228,6 @@ class Linker(AbstractEntityProvidingComponent):
             return_tensors="pt",
         ).to(device)
         outputs = self.model(**batch_dict)
-        outputs = self._last_token_pool(
-            outputs.last_hidden_state, batch_dict["attention_mask"]
-        )
-        outputs = F.normalize(outputs, p=2, dim=1)
         return outputs.half()
 
     def _get_context(
@@ -550,20 +547,6 @@ class Linker(AbstractEntityProvidingComponent):
             return context_similarity >= threshold
         else:
             return True
-
-    def _last_token_pool(
-        self, last_hidden_states: Tensor, attention_mask: Tensor
-    ) -> Tensor:
-        left_padding = attention_mask[:, -1].sum() == attention_mask.shape[0]
-        if left_padding:
-            return last_hidden_states[:, -1]
-        else:
-            sequence_lengths = attention_mask.sum(dim=1) - 1
-            batch_size = last_hidden_states.shape[0]
-            return last_hidden_states[
-                torch.arange(batch_size, device=last_hidden_states.device),
-                sequence_lengths,
-            ]
 
     def _build_context_matrices(self) -> None:
         if "name_embeddings" in self.cdb.addl_info:

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/embedding_linker.py
@@ -48,6 +48,7 @@ class Linker(AbstractEntityProvidingComponent):
         if not isinstance(config.components.linking, EmbeddingLinking):
             raise TypeError("Linking config must be an EmbeddingLinking instance")
         self.cnf_l: EmbeddingLinking = config.components.linking
+        self.max_length: Optional[int] = self.cnf_l.max_token_length
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
         resolved_model_init_kwargs: dict[str, Any] = dict(
@@ -139,7 +140,7 @@ class Linker(AbstractEntityProvidingComponent):
 
     def _get_context(
         self, entity: MutableEntity, doc: MutableDocument, size: int
-    ) -> str:
+    ) -> tuple[str, tuple[int, int]]:
         """Get context tokens for an entity
 
         Args:
@@ -148,8 +149,8 @@ class Linker(AbstractEntityProvidingComponent):
             size (int): The size of the entity.
 
         Returns:
-            tuple[list[BaseToken], list[BaseToken], list[BaseToken]]:
-                The tokens on the left, centre, and right.
+            tuple[str, tuple[int, int]]:
+                The context text and the span of the entity within that text.
         """
         # Token indices of the entity
         start_token_idx = entity.base.start_index

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/embedding_linker.py
@@ -414,13 +414,13 @@ class Linker(AbstractEntityProvidingComponent):
             if len(link_candidates) == 1:
                 best_idx = self._cui_to_idx[link_candidates[0]]
                 predicted_cui = link_candidates[0]
-                if best_idx < 0 or best_idx >= names_scores.shape[1]:
+                if best_idx < 0 or best_idx >= cui_scores.shape[1]:
                     logger.warning(
                         "Skipping entity '%s': single-candidate index %s is out of "
-                        "bounds for names_scores width %s.",
+                        "bounds for cui_scores width %s.",
                         entity.detected_name,
                         best_idx,
-                        names_scores.shape[1],
+                        cui_scores.shape[1],
                     )
                     continue
                 similarity = cui_scores[i, best_idx].item()
@@ -581,6 +581,7 @@ class Linker(AbstractEntityProvidingComponent):
             logger.warning(
                 "Attemping to train a static embedding linker. "
                 "This is not possible / required."
+                "Use the `trainable_embedding_linker` instead."
             )
         if self.cnf_l.filters.cuis and self.cnf_l.filters.cuis_exclude:
             logger.warning(

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/embedding_linker.py
@@ -4,34 +4,43 @@ from medcat.components.types import CoreComponentType
 from medcat.components.types import AbstractEntityProvidingComponent
 from medcat.tokenizing.tokens import MutableEntity, MutableDocument
 from medcat.tokenizing.tokenizers import BaseTokenizer
-from medcat_embedding_linker.transformer_context_model import ModelForEmbeddingLinking
-from typing import Optional, Iterator, Set
+from medcat_embedding_linker.transformer_context_model import ContextModel
+from typing import Optional, Iterator, Set, Any
 from medcat.vocab import Vocab
 from medcat.utils.postprocessing import filter_linked_annotations
-from tqdm import tqdm
-from collections import defaultdict
-import logging
-import math
-import numpy as np
-
 from medcat_embedding_linker.config import EmbeddingLinking
-
+from collections import defaultdict
 from torch import Tensor
-from transformers import AutoTokenizer, AutoModel
-import torch.nn.functional as F
+import logging
+import numpy as np
 import torch
 
 logger = logging.getLogger(__name__)
 
 
 class Linker(AbstractEntityProvidingComponent):
-    name = "embedding_linker"
+    comp_name = "embedding_linker"
+    _MODEL_FOLDER_NAME = "embedding_model"
+    _STATE_FILE_NAME = "state.json"
 
-    def __init__(self, cdb: CDB, config: Config) -> None:
+    # default model kwargs for embedding linkers that do not require training
+    DEFAULT_MODEL_INIT_KWARGS = {
+        "use_projection_layer": False,
+        "top_n_layers_to_unfreeze": 0,
+    }
+
+    def __init__(
+        self,
+        cdb: CDB,
+        config: Config,
+        model_init_kwargs: Optional[dict[str, Any]] = None,
+    ) -> None:
         """Initializes the embedding linker with a CDB and configuration.
         Args:
             cdb (CDB): The concept database to use.
             config (Config): The base config.
+            model_init_kwargs (Optional[dict[str, Any]]): Explicit kwargs that
+                override linker defaults.
         """
         super().__init__()
         self.cdb = cdb
@@ -39,23 +48,19 @@ class Linker(AbstractEntityProvidingComponent):
         if not isinstance(config.components.linking, EmbeddingLinking):
             raise TypeError("Linking config must be an EmbeddingLinking instance")
         self.cnf_l: EmbeddingLinking = config.components.linking
-        self.max_length = self.cnf_l.max_token_length
         self.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-        self._name_keys = list(self.cdb.name2info)
-        self._cui_keys = list(self.cdb.cui2info)
+        resolved_model_init_kwargs: dict[str, Any] = dict(
+            self.DEFAULT_MODEL_INIT_KWARGS
+        )
+        resolved_model_init_kwargs.update(model_init_kwargs or {})
 
-        # these only need to be populated when called for embedding or inference
-        self._names_context_matrix = None
-        self._cui_context_matrix = None
-
-        # used for filters and name embedding, and if the name contains a valid cui 
-        # see: _set_filters
-        self._last_include_set: Optional[Set[str]] = None
-        self._last_exclude_set: Optional[Set[str]] = None
-        self._allowed_mask = None
-        self._name_has_allowed_cui = None
-
+        self.context_model = ContextModel(
+            cdb=self.cdb,
+            linking_config=self.cnf_l,
+            separator=self.config.general.separator,
+            model_init_kwargs=resolved_model_init_kwargs,
+        )
         # checking for config settings that aren't used in this linker
         if self.cnf_l.prefer_frequent_concepts:
             logger.warning(
@@ -70,6 +75,26 @@ class Linker(AbstractEntityProvidingComponent):
                 "in the embedding linker. It is currently set to "
                 f"{self.cnf_l.prefer_primary_name}."
             )
+        self.refresh_structure()
+
+    def refresh_structure(self) -> None:
+        """Call this method after making changes to the CDB to update internal 
+        structures. Called upon initialization, and can be called manually after 
+        CDB modifications. This is usually required when training on data that 
+        might have new cuis or names."""
+        self._name_keys = list(self.cdb.name2info)
+        self._cui_keys = list(self.cdb.cui2info)
+
+        # Clear context matrices to force re-embedding with new CDB structure
+        self._names_context_matrix = None
+        self._cui_context_matrix = None
+
+        # used for filters and name embedding, and if the name contains a valid cui
+        # see: _set_filters
+        self._last_include_set: Optional[Set[str]] = None
+        self._last_exclude_set: Optional[Set[str]] = None
+        self._allowed_mask = None
+        self._name_has_allowed_cui = None
 
         self._cui_to_idx = {cui: idx for idx, cui in enumerate(self._cui_keys)}
         self._name_to_idx = {name: idx for idx, name in enumerate(self._name_keys)}
@@ -83,107 +108,27 @@ class Linker(AbstractEntityProvidingComponent):
         ]
         self._initialize_filter_structures()
 
-    def create_embeddings(self,
-                          embedding_model_name: Optional[str] = None,
-                          max_length: Optional[int] = None,
-                          ):
-        """Create embeddings for all names and cuis longest names in the CDB 
-        using the chosen embedding model."""
+    def create_embeddings(
+        self,
+        embedding_model_name: Optional[str] = None,
+        max_length: Optional[int] = None,
+    ) -> None:
+        """Create both CUI and name embeddings in CDB."""
         if embedding_model_name is None:
-            embedding_model_name = self.cnf_l.embedding_model_name  # fallback
+            embedding_model_name = self.cnf_l.embedding_model_name
 
         if max_length is not None and max_length != self.max_length:
             logger.info(
-            "Updating max_length from %s to %s", self.max_length, max_length
+                "Updating max_length from %s to %s", self.max_length, max_length
             )
             self.max_length = max_length
             self.cnf_l.max_token_length = max_length
-        if (
-            embedding_model_name == self.cnf_l.embedding_model_name
-            and "cui_embeddings" in self.cdb.addl_info
-        ):
-            logger.warning("Using the same model for embedding names.")
-        else:
-            self.cnf_l.embedding_model_name = embedding_model_name
-        self._load_transformers(embedding_model_name)
-        self._embed_cui_names(embedding_model_name)
-        self._embed_names(embedding_model_name)
 
-    def _embed_cui_names(
-        self,
-        embedding_model_name: str,
-    ) -> None:
-        """Obtain embeddings for all cuis longest names in the CDB using the specified
-        embedding model and store them in the name2info.context_vectors
-        Args:
-            embedding_model_name (str): The name of the embedding model to use.
-            batch_size (int): The size of the batches to use when embedding names. 
-            Default 4096
-        """
-        if (
-            embedding_model_name == self.cnf_l.embedding_model_name
-            and "cui_embeddings" in self.cdb.addl_info
-            and "name_embeddings" in self.cdb.addl_info
-        ):
-            logger.warning("Using the same model for embedding.")
-        else:
-            self.cnf_l.embedding_model_name = embedding_model_name
+        self.context_model.embed_cuis(embedding_model_name)
+        self.context_model.embed_names(embedding_model_name)
 
-        # Use the longest name
-        cui_names = [
-            max(self.cdb.cui2info[cui]["names"], key=len) for cui in self._cui_keys
-        ]
-        # embed each name in batches. Because there can be 3+ million names
-        total_batches = math.ceil(len(cui_names) / self.cnf_l.embedding_batch_size)
-        all_embeddings = []
-        for names in tqdm(
-            self._batch_data(cui_names, self.cnf_l.embedding_batch_size),
-            total=total_batches,
-            desc="Embedding cuis' preferred names",
-        ):
-            with torch.no_grad():
-                # removing ~ from names, as it is used to indicate a space in the CDB
-                names_to_embed = [
-                    name.replace(self.config.general.separator, " ") for name in names
-                ]
-                embeddings = self._embed(names_to_embed, self.device)
-                all_embeddings.append(embeddings.cpu())
-        # cat all batches into one tensor
-        all_embeddings_matrix = torch.cat(all_embeddings, dim=0)
-        self.cdb.addl_info["cui_embeddings"] = all_embeddings_matrix
-        logger.debug("Embedding cui names done, total: %d", len(names))
-
-    def _embed_names(self, embedding_model_name: str) -> None:
-        """Obtain embeddings for all names in the CDB using the specified
-        embedding model and store them in the name2info.context_vectors
-        Args:
-            embedding_model_name (str): The name of the embedding model to use.
-            batch_size (int): The size of the batches to use when embedding names
-            Default 4096
-        """
-        if embedding_model_name == self.cnf_l.embedding_model_name:
-            logger.debug("Using the same model for embedding names.")
-        else:
-            self.cnf_l.embedding_model_name = embedding_model_name
-        names = self._name_keys
-        # embed each name in batches. Because there can be 3+ million names
-        total_batches = math.ceil(len(names) / self.cnf_l.embedding_batch_size)
-        all_embeddings = []
-        for names in tqdm(
-            self._batch_data(names, self.cnf_l.embedding_batch_size),
-            total=total_batches,
-            desc="Embedding names",
-        ):
-            with torch.no_grad():
-                # removing ~ from names, as it is used to indicate a space in the CDB
-                names_to_embed = [
-                    name.replace(self.config.general.separator, " ") for name in names
-                ]
-                embeddings = self._embed(names_to_embed, self.device)
-                all_embeddings.append(embeddings.cpu())
-        all_embeddings_matrix = torch.cat(all_embeddings, dim=0)
-        self.cdb.addl_info["name_embeddings"] = all_embeddings_matrix
-        logger.debug("Embedding names done, total: %d", len(names))
+        self._names_context_matrix = None
+        self._cui_context_matrix = None
 
     def get_type(self) -> CoreComponentType:
         return CoreComponentType.linking
@@ -191,44 +136,6 @@ class Linker(AbstractEntityProvidingComponent):
     def _batch_data(self, data, batch_size=512) -> Iterator[list]:
         for i in range(0, len(data), batch_size):
             yield data[i : i + batch_size]
-
-    def _load_transformers(self, embedding_model_name: str) -> None:
-        """Load the transformers model and tokenizer.
-        No need to load a transformer model until it's required.
-        Args:
-            embedding_model_name (str): The name of the embedding model to load. 
-            Default is "sentence-transformers/all-MiniLM-L6-v2"
-        """
-        if (
-            not hasattr(self, "model")
-            or not hasattr(self, "tokenizer")
-            or embedding_model_name != self.cnf_l.embedding_model_name
-        ):
-            self.cnf_l.embedding_model_name = embedding_model_name
-            self.tokenizer = AutoTokenizer.from_pretrained(embedding_model_name)
-            self.model = ModelForEmbeddingLinking.from_pretrained(embedding_model_name)
-            self.model.eval()
-            gpu_device = self.cnf_l.gpu_device
-            self.device = torch.device(
-                gpu_device or ("cuda" if torch.cuda.is_available() else "cpu")
-            )
-            self.model.to(self.device)
-            logger.debug(
-                f"""Loaded embedding model: {embedding_model_name} 
-                on device: {self.device}"""
-            )
-
-    def _embed(self, to_embed: list[str], device) -> Tensor:
-        """Embeds a list of strings"""
-        batch_dict = self.tokenizer(
-            to_embed,
-            max_length=self.max_length,
-            padding=True,
-            truncation=True,
-            return_tensors="pt",
-        ).to(device)
-        outputs = self.model(**batch_dict)
-        return outputs.half()
 
     def _get_context(
         self, entity: MutableEntity, doc: MutableDocument, size: int
@@ -244,22 +151,37 @@ class Linker(AbstractEntityProvidingComponent):
             tuple[list[BaseToken], list[BaseToken], list[BaseToken]]:
                 The tokens on the left, centre, and right.
         """
-        start_ind = entity.base.start_index
-        end_ind = entity.base.end_index
+        # Token indices of the entity
+        start_token_idx = entity.base.start_index
+        end_token_idx = entity.base.end_index
 
-        left_most_token = doc[max(0, start_ind - size)]
-        left_index = left_most_token.base.char_index
+        # Define token window
+        left_token_idx = max(0, start_token_idx - size)
+        right_token_idx = min(len(doc) - 1, end_token_idx + size)
 
-        right_most_token = doc[min(len(doc) - 1, end_ind + size)]
-        right_index = right_most_token.base.char_index + len(right_most_token.base.text)
+        # Convert tokens → character offsets
+        left_most_token = doc[left_token_idx]
+        right_most_token = doc[right_token_idx]
 
-        snippet = doc.base.text[left_index:right_index]
-        return snippet
+        # For mention masking
+        snippet_start_char = left_most_token.base.char_index
+        snippet_end_char = right_most_token.base.char_index + len(
+            right_most_token.base.text
+        )
+
+        # Slice raw document text
+        snippet = doc.base.text[snippet_start_char:snippet_end_char]
+
+        # Compute entity span relative to snippet
+        mention_start = entity.base.start_char_index - snippet_start_char
+        mention_end = entity.base.end_char_index - snippet_start_char
+
+        return snippet, (mention_start, mention_end)
 
     def _get_context_vectors(
         self, doc: MutableDocument, entities: list[MutableEntity], size: int
     ) -> Tensor:
-        """Get context vectors for all detected concepts based on their 
+        """Get context vectors for all detected concepts based on their
         surrounding text.
 
         Args:
@@ -269,40 +191,41 @@ class Linker(AbstractEntityProvidingComponent):
             tuple[list[BaseToken], list[BaseToken], list[BaseToken]]:
                 The tokens on the left, centre, and right."""
         texts = []
+        mention_spans = []
         for entity in entities:
-            text = self._get_context(entity, doc, size)
+            text, span = self._get_context(entity, doc, size)
             texts.append(text)
-        return self._embed(texts, self.device)
+            mention_spans.append(span)
+        return self.context_model.embed(texts, mention_spans, self.device)
 
     def _initialize_filter_structures(self) -> None:
         """Call once during initialization to create efficient lookup structures."""
         # Build an inverted index: cui_idx -> list of name indices that contain it
         # This is the KEY optimization - we flip the lookup direction
-        if not hasattr(self, '_cui_idx_to_name_idxs'):
-            cui2name_indices: defaultdict[
-                int, list[int]] = defaultdict(list)
+        cui2name_indices: defaultdict[int, list[int]] = defaultdict(list)
 
-            for name_idx, cui_idxs in enumerate(self._name_to_cui_idxs):
-                for cui_idx in cui_idxs:
-                    cui2name_indices[cui_idx].append(name_idx)
+        for name_idx, cui_idxs in enumerate(self._name_to_cui_idxs):
+            for cui_idx in cui_idxs:
+                cui2name_indices[cui_idx].append(name_idx)
 
-            # Convert lists to numpy arrays for faster indexing
-            self._cui_idx_to_name_idxs = {
-                cui_idx: np.array(name_idxs, dtype=np.int32)
-                for cui_idx, name_idxs in cui2name_indices.items()
-            }
+        # Convert lists to numpy arrays for faster indexing
+        self._cui_idx_to_name_idxs = {
+            cui_idx: np.array(name_idxs, dtype=np.int32)
+            for cui_idx, name_idxs in cui2name_indices.items()
+        }
 
-        # Cache _has_cuis_all
-        if not hasattr(self, '_has_cuis_all_cached'):
-            self._has_cuis_all_cached = torch.tensor(
-                [bool(self.cdb.name2info[name]["per_cui_status"])
-                 for name in self._name_keys],
-                device=self.device,
-                dtype=torch.bool,
-            )
+        # This used to be checked to be cached.
+        # But whenever it is called it is needed.
+        self._has_cuis_all_cached = torch.tensor(
+            [
+                bool(self.cdb.name2info[name]["per_cui_status"])
+                for name in self._name_keys
+            ],
+            device=self.device,
+            dtype=torch.bool,
+        )
 
-    def _get_include_filters_1cui(
-            self, cui: str, n: int) -> torch.Tensor:
+    def _get_include_filters_1cui(self, cui: str, n: int) -> torch.Tensor:
         """Optimized single CUI include filter using inverted index."""
         if cui not in self._cui_to_idx:
             return torch.zeros(n, dtype=torch.bool, device=self.device)
@@ -321,11 +244,11 @@ class Linker(AbstractEntityProvidingComponent):
             return torch.zeros(n, dtype=torch.bool, device=self.device)
 
     def _get_include_filters_multi_cui(
-            self, include_set: Set[str], n: int) -> torch.Tensor:
+        self, include_set: Set[str], n: int
+    ) -> torch.Tensor:
         """Optimized multi-CUI include filter using inverted index."""
         include_cui_idxs = [
-            self._cui_to_idx[cui] for cui in include_set
-            if cui in self._cui_to_idx
+            self._cui_to_idx[cui] for cui in include_set if cui in self._cui_to_idx
         ]
 
         if not include_cui_idxs:
@@ -335,33 +258,30 @@ class Linker(AbstractEntityProvidingComponent):
         all_name_indices_list: list[np.ndarray] = []
         for cui_idx in include_cui_idxs:
             if cui_idx in self._cui_idx_to_name_idxs:
-                all_name_indices_list.append(
-                    self._cui_idx_to_name_idxs[cui_idx])
+                all_name_indices_list.append(self._cui_idx_to_name_idxs[cui_idx])
 
         if not all_name_indices_list:
             return torch.zeros(n, dtype=torch.bool, device=self.device)
 
         # Concatenate and get unique indices
-        all_name_indices = np.unique(
-            np.concatenate(all_name_indices_list))
+        all_name_indices = np.unique(np.concatenate(all_name_indices_list))
 
         # Create mask
         allowed_mask = torch.zeros(n, dtype=torch.bool, device=self.device)
         allowed_mask[torch.from_numpy(all_name_indices).to(self.device)] = True
         return allowed_mask
 
-    def _get_include_filters(
-            self, include_set: Set[str], n: int) -> torch.Tensor:
+    def _get_include_filters(self, include_set: Set[str], n: int) -> torch.Tensor:
         """Route to appropriate include filter method."""
         if len(include_set) == 1:
             cui = next(iter(include_set))
             return self._get_include_filters_1cui(cui, n)
         else:
-            return self._get_include_filters_multi_cui(
-                include_set, n)
+            return self._get_include_filters_multi_cui(include_set, n)
 
     def _get_exclude_filters_1cui(
-            self, allowed_mask: torch.Tensor, cui: str) -> torch.Tensor:
+        self, allowed_mask: torch.Tensor, cui: str
+    ) -> torch.Tensor:
         """Optimized single CUI exclude filter using inverted index."""
         if cui not in self._cui_to_idx:
             return allowed_mask
@@ -371,18 +291,18 @@ class Linker(AbstractEntityProvidingComponent):
         if cui_idx in self._cui_idx_to_name_idxs:
             name_indices = self._cui_idx_to_name_idxs[cui_idx]
             # Set specific indices to False
-            allowed_mask[
-                torch.from_numpy(name_indices).to(self.device)] = False
+            allowed_mask[torch.from_numpy(name_indices).to(self.device)] = False
 
         return allowed_mask
 
     def _get_exclude_filters_multi_cui(
-            self, allowed_mask: torch.Tensor, exclude_set: Set[str],
-            ) -> torch.Tensor:
+        self,
+        allowed_mask: torch.Tensor,
+        exclude_set: Set[str],
+    ) -> torch.Tensor:
         """Optimized multi-CUI exclude filter using inverted index."""
         exclude_cui_idxs = [
-            self._cui_to_idx[cui] for cui in exclude_set
-            if cui in self._cui_to_idx
+            self._cui_to_idx[cui] for cui in exclude_set if cui in self._cui_to_idx
         ]
 
         if not exclude_cui_idxs:
@@ -400,8 +320,7 @@ class Linker(AbstractEntityProvidingComponent):
 
         return allowed_mask
 
-    def _get_exclude_filters(
-            self, exclude_set: Set[str], n: int) -> torch.Tensor:
+    def _get_exclude_filters(self, exclude_set: Set[str], n: int) -> torch.Tensor:
         """Route to appropriate exclude filter method."""
         # Start with all allowed
         allowed_mask = torch.ones(n, dtype=torch.bool, device=self.device)
@@ -411,11 +330,9 @@ class Linker(AbstractEntityProvidingComponent):
 
         if len(exclude_set) == 1:
             cui = next(iter(exclude_set))
-            return self._get_exclude_filters_1cui(
-                allowed_mask, cui)
+            return self._get_exclude_filters_1cui(allowed_mask, cui)
         else:
-            return self._get_exclude_filters_multi_cui(
-                allowed_mask, exclude_set)
+            return self._get_exclude_filters_multi_cui(allowed_mask, exclude_set)
 
     def _set_filters(self) -> None:
         include_set = self.cnf_l.filters.cuis
@@ -433,11 +350,9 @@ class Linker(AbstractEntityProvidingComponent):
         n = len(self._name_keys)
 
         if include_set:
-            allowed_mask = self._get_include_filters(
-                include_set, n)
+            allowed_mask = self._get_include_filters(include_set, n)
         else:
-            allowed_mask = self._get_exclude_filters(
-                exclude_set, n)
+            allowed_mask = self._get_exclude_filters(exclude_set, n)
 
         self._valid_names = self._has_cuis_all_cached & allowed_mask
         self._last_include_set = set(include_set) if include_set is not None else None
@@ -456,7 +371,9 @@ class Linker(AbstractEntityProvidingComponent):
             tuple[str, float]:
                 The CUI and its similarity
         """
-        cui_idxs = [self._cui_to_idx[cui] for cui in cui_candidates]
+        cui_idxs = [
+            self._cui_to_idx[cui] for cui in cui_candidates if cui in self._cui_to_idx
+        ]
         candidate_scores = scores[cui_idxs]
         candidate_idx = int(torch.argmax(candidate_scores).item())
         best_idx = cui_idxs[candidate_idx]
@@ -496,16 +413,36 @@ class Linker(AbstractEntityProvidingComponent):
             if len(link_candidates) == 1:
                 best_idx = self._cui_to_idx[link_candidates[0]]
                 predicted_cui = link_candidates[0]
-                similarity = names_scores[i, best_idx].item()
+                if best_idx < 0 or best_idx >= names_scores.shape[1]:
+                    logger.warning(
+                        "Skipping entity '%s': single-candidate index %s is out of "
+                        "bounds for names_scores width %s.",
+                        entity.detected_name,
+                        best_idx,
+                        names_scores.shape[1],
+                    )
+                    continue
+                similarity = cui_scores[i, best_idx].item()
             elif len(link_candidates) > 1:
                 name_to_cuis = defaultdict(list)
                 for cui in link_candidates:
                     for name in self.cdb.cui2info[cui]["names"]:
                         name_to_cuis[name].append(cui)
 
-                name_idxs = [self._name_to_idx[name] for name in name_to_cuis]
+                name_idxs = [
+                    self._name_to_idx[name]
+                    for name in name_to_cuis
+                    if name in self._name_to_idx
+                ]
+                if name_idxs == []:
+                    logger.warning(
+                        "No valid name indices for entity '%s' link candidates. "
+                        "Likely stale linker structure after CDB mutation; call "
+                        "refresh_structure() and recreate embeddings.",
+                        entity.detected_name,
+                    )
+                    continue
                 indexed_scores = names_scores[i, name_idxs]
-
                 best_local_pos = int(torch.argmax(indexed_scores).item())
                 best_global_idx = name_idxs[best_local_pos]
                 similarity = names_scores[i, best_global_idx].item()
@@ -534,9 +471,7 @@ class Linker(AbstractEntityProvidingComponent):
                 predicted_cui, _ = self._disambiguate_by_cui(cuis, cui_scores[i, :])
             if not self.cnf_l.filters.check_filters(predicted_cui):
                 continue
-            if self._check_similarity(
-                similarity
-            ):
+            if self._check_similarity(similarity):
                 entity.cui = predicted_cui
                 entity.context_similarity = similarity
                 yield entity
@@ -596,7 +531,8 @@ class Linker(AbstractEntityProvidingComponent):
 
             entity.link_candidates = list(cuis)
 
-    def _pre_inference(self, doc: MutableDocument
+    def _pre_inference(
+        self, doc: MutableDocument
     ) -> tuple[list[MutableEntity], list[MutableEntity]]:
         """Checking all entities for entites with only a single link candidate and to
         avoid full inference step. If we want to calculate similarities, or not use
@@ -637,23 +573,13 @@ class Linker(AbstractEntityProvidingComponent):
             to_infer.append(entity)
         return le, to_infer
 
-    def predict_entities(self, doc: MutableDocument,
-                         ents: list[MutableEntity] | None = None
-                         ) -> list[MutableEntity]:
-        if self.cdb.is_dirty:
-            logging.warning(
-                "CDB has been modified since last save/load. "
-                "This might significantly affect linking performance."
-            )
-            logging.warning(
-                "If you have added new concepts or changes, "
-                "please re-embed the CDB names and cuis before linking."
-            )
-
-        self._load_transformers(self.cnf_l.embedding_model_name)
-        if self.cnf_l.train:
+    def predict_entities(
+        self, doc: MutableDocument, ents: list[MutableEntity] | None = None
+    ) -> list[MutableEntity]:
+        if self.cnf_l.train and self.comp_name == "embedding_linker":
             logger.warning(
-                "Attemping to train an embedding linker. This is not required."
+                "Attemping to train a static embedding linker. "
+                "This is not possible / required."
             )
         if self.cnf_l.filters.cuis and self.cnf_l.filters.cuis_exclude:
             logger.warning(

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/registration.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/registration.py
@@ -1,4 +1,3 @@
-
 import logging
 
 from medcat.components.types import CoreComponentType
@@ -10,5 +9,14 @@ logger = logging.getLogger(__name__)
 
 def do_registration():
     lazy_register_core_component(
-        CoreComponentType.linking, "embedding_linker",
-        "medcat_embedding_linker.embedding_linker", "Linker.create_new_component")
+        CoreComponentType.linking,
+        "embedding_linker",
+        "medcat_embedding_linker.embedding_linker",
+        "Linker.create_new_component",
+    )
+    lazy_register_core_component(
+        CoreComponentType.linking,
+        "trainable_embedding_linker",
+        "medcat_embedding_linker.trainable_embedding_linker",
+        "Linker.create_new_component",
+    )

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
@@ -239,7 +239,7 @@ class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
             all_positive_name_idxs_per_row,
         )
 
-    def train_on_batch(self) -> None:
+    def _train_on_batch(self) -> None:
         """Train on the current batch, dispatching to names or CUI mode.
 
         This should also be called manually at the end of training to flush any 
@@ -326,9 +326,15 @@ class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
             if positive_cui_idx is None:
                 return
             self.training_batch.append((doc, entity, positive_cui_idx))
-        # Train as soon as the batch is full.
-        if len(self.training_batch) >= self.cnf_l.training_batch_size:
-            self.train_on_batch()
+        if (
+            len(self.training_batch) >= self.cnf_l.training_batch_size 
+            or entity is doc.ner_ents[-1]
+        ):
+            logger.debug(
+                "End of document reached; training on final batch of size %s",
+                len(self.training_batch),
+            )
+            self._train_on_batch()
             self.training_batch = []
             self.number_of_batches += 1
         # If you've got as many batches as you want before re-embedding, 
@@ -337,10 +343,9 @@ class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
             self.cnf_l.embed_per_n_batches > 0
             and self.number_of_batches > self.cnf_l.embed_per_n_batches
         ):
-            print(
-                "Re-embedding names and CUIs after training on {} batches.".format(
-                    self.number_of_batches
-                )
+            logger.debug(
+                "Re-embedding names and CUIs after training on %s batches.",
+                self.number_of_batches,
             )
             self.refresh_structure()
             # Always refresh both embeddings to keep CDB and embeddings in sync.
@@ -367,7 +372,6 @@ class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
         # Ensure final partial batch is not dropped before saving model state.
         logger.info("Flushing final training batch before saving model.")
         logger.info("This is grandfathered in from trainer.py restraints.")
-        self.train_on_batch()
 
         os.makedirs(folder_path, exist_ok=True)
         model_folder = os.path.join(folder_path, self._MODEL_FOLDER_NAME)

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
@@ -328,10 +328,11 @@ class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
             self.training_batch.append((doc, entity, positive_cui_idx))
         if (
             len(self.training_batch) >= self.cnf_l.training_batch_size 
-            or entity is doc.ner_ents[-1]
+            or entity is doc.linked_ents[-1]
         ):
             logger.debug(
-                "End of document reached; training on final batch of size %s",
+                "End of document reached or full batch; " \
+                "training on a batch of size %s",
                 len(self.training_batch),
             )
             self._train_on_batch()

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
@@ -7,80 +7,291 @@ from medcat.tokenizing.tokenizers import BaseTokenizer
 from medcat.tokenizing.tokens import MutableDocument, MutableEntity
 from medcat.vocab import Vocab
 from medcat_embedding_linker.embedding_linker import Linker
+from medcat.storage.serialisables import AbstractManualSerialisable
 import logging
 import torch
+import os
+import random
 
 logger = logging.getLogger(__name__)
 
-class TrainableEmbeddingLinker(Linker):
+
+class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
     """Trainable variant of the embedding linker.
-	This class inherits inference and embedding behavior from Linker and provides
-	method hooks for online/offline training.
-	"""
-    name = "embedding_linker"
+    This class inherits inference and embedding behavior from Linker and provides
+    method hooks for online/offline training.
+    """
+
+    comp_name = "trainable_embedding_linker"
+    _MODEL_FOLDER_NAME = "trainable_embedding_model"
+    _MODEL_STATE_FILE_NAME = "model_state.pt"
 
     def __init__(self, cdb: CDB, config: Config) -> None:
-        super().__init__(cdb, config)
-        self.is_training = False
+        linking_cfg = config.components.linking
+        # these by default are True, and 0
+        # so a projection layer is used, but only the projection is trained
+        model_init_kwargs = {
+            "use_projection_layer": linking_cfg.use_projection_layer,
+            "top_n_layers_to_unfreeze": linking_cfg.top_n_layers_to_unfreeze,
+        }
+        super().__init__(
+            cdb,
+            config,
+            model_init_kwargs=model_init_kwargs,
+        )
+        self.training_batch: list[tuple] = []
+        self.number_of_batches = 0
+        self.negative_sampling_candidate_pool_size = (
+            linking_cfg.negative_sampling_candidate_pool_size
+        )
+        self.scaler = torch.amp.GradScaler()  # for FP16 training stability
+        self.optimizer = torch.optim.AdamW(
+            self.context_model.model.parameters(), lr=1e-4, weight_decay=0.01
+        )
 
-    def _generate_negative_samples(self, candidate_indices: Tensor, names_scores: Tensor, positive_name_idxs: list[int]) -> list[str]:
-        """Generate negative samples for a given entity and its true CUI.
+    def _generate_negative_samples(
+        self,
+        candidate_indices: Tensor,
+        candidate_scores: Tensor,
+        positive_target_idxs_per_row: list[list[int]],
+    ) -> Tensor:
+        """Sample negative target indices for each entity in a batch.
+
         Args:
-            candidate_indices (Tensor): The indices of the candidate CUIs.
-            names_scores (Tensor): The scores for each name.
-            gold_cui_idx (int): The index of the ground truth CUI.
+            candidate_indices (Tensor): Candidate target indices, shape
+                ``[batch, num_candidates]``.
+            candidate_scores (Tensor): Scores for candidate targets aligned with
+                ``candidate_indices``, shape ``[batch, num_candidates]``.
+            positive_target_idxs_per_row (list[list[int]]): Per-row target indices that
+                must be excluded from negatives.
+
         Returns:
-            list[str]: A list of negative sample CUIs.
+            Tensor: Sampled negative name indices with shape ``[batch, k]`` (or
+            ``[k]`` for single-item input).
         """
         k = self.cnf_l.negative_sampling_k
         temperature = self.cnf_l.negative_sampling_temperature
 
-        # Gather scores for the sorted candidates
-        candidate_scores = names_scores[candidate_indices]
+        # Exclude positives from sampling by masking their scores.
+        positive_mask = torch.zeros_like(candidate_indices, dtype=torch.bool)
+        for row_idx, row_positive_idxs in enumerate(positive_target_idxs_per_row):
+            if not row_positive_idxs:
+                continue
+            row_positive_tensor = torch.tensor(
+                row_positive_idxs,
+                device=candidate_indices.device,
+                dtype=candidate_indices.dtype,
+            )
+            positive_mask[row_idx] = torch.isin(
+                candidate_indices[row_idx],
+                row_positive_tensor,
+            )
+        candidate_scores = candidate_scores.masked_fill(positive_mask, float("-inf"))
 
-        # Temperature scaling
-        probs = torch.softmax(candidate_scores / temperature, dim=0)
+        probs = torch.softmax(candidate_scores / temperature, dim=1)
+        probs = torch.nan_to_num(probs, nan=0.0, posinf=0.0, neginf=0.0)
 
-        # Sample negatives
+        max_samples = min(k, candidate_indices.size(1))
+        valid_counts = (~positive_mask).sum(dim=1)
+        sample_count = min(max_samples, int(valid_counts.min().item()))
+        if sample_count <= 0:
+            return candidate_indices.new_empty((candidate_indices.size(0), 0))
+
         sampled_positions = torch.multinomial(
             probs,
-            num_samples=min(k, len(candidate_indices)),
-            replacement=False
+            num_samples=sample_count,
+            replacement=False,
         )
-
-        negative_indices = candidate_indices[sampled_positions]
+        negative_indices = torch.gather(
+            candidate_indices, dim=1, index=sampled_positions
+        )
         return negative_indices
 
-    def _train_on_batch(self, entities: list[MutableEntity], doc: MutableDocument, positive_name_idxs: list[int]) -> None:
-        """Train on a batch of entities and their corresponding document.
+    def _build_batch_context_inputs(
+        self, batch: list[tuple]
+    ) -> tuple[list[str], list[tuple[int, int]]]:
+        """Convert a batch into model-ready text snippets and mention spans."""
+        texts: list[str] = []
+        mention_spans: list[tuple[int, int]] = []
+        for doc, entity, *_ in batch:
+            snippet, mention_span = self._get_context(
+                entity,
+                doc,
+                self.cnf_l.context_window_size,
+            )
+            texts.append(snippet)
+            mention_spans.append(mention_span)
+        return texts, mention_spans
+
+    def _train_on_batch_targets(
+        self,
+        target_matrix: Tensor,
+        positive_target_idxs: list[int],
+        all_positive_target_idxs_per_row: list[list[int]],
+    ) -> None:
+        """Shared contrastive training path for both name and CUI targets."""
+        if self.training_batch == []:
+            return
+
+        texts, mention_spans = self._build_batch_context_inputs(self.training_batch)
+
+        self.optimizer.zero_grad()
+        with torch.amp.autocast(
+            device_type=str(self.device)
+        ):  # controls FP16 usage for better stability
+            # Forward pass to get context vectors for each entity in the batch.
+            self.context_model.model.train()
+
+            context_vectors = self.context_model.embed(
+                texts,
+                mention_spans=mention_spans,
+            )  # [batch, dim]
+
+            # Target embeddings are fixed; no gradient flows through them.
+            target_matrix = target_matrix.detach()  # [num_targets, dim]
+
+            # Negative sampling does not need gradients.
+            with torch.no_grad():
+                target_scores = context_vectors.detach() @ target_matrix.T
+                candidate_pool_size = min(
+                    target_scores.size(1), self.negative_sampling_candidate_pool_size
+                )
+
+                candidate_scores, candidate_indices = torch.topk(
+                    target_scores,
+                    k=candidate_pool_size,
+                    dim=1,
+                    largest=True,
+                    sorted=False,
+                )
+                negative_indices = self._generate_negative_samples(
+                    candidate_indices,
+                    candidate_scores,
+                    all_positive_target_idxs_per_row,
+                )
+
+            pos_idx_tensor = torch.tensor(positive_target_idxs, device=self.device)
+            positive_embeds = target_matrix[pos_idx_tensor]
+            negative_embeds = target_matrix[negative_indices]
+
+            positive_scores = (context_vectors * positive_embeds).sum(
+                dim=1, keepdim=True
+            )
+            negative_scores = torch.bmm(
+                negative_embeds, context_vectors.unsqueeze(-1)
+            ).squeeze(-1)
+
+            logits = torch.cat([positive_scores, negative_scores], dim=1)
+            # The target is always the first position (the positive sample).
+            # So these are idx's of 0 in the logits tensor, not target indices.
+            targets = torch.zeros(
+                len(self.training_batch), dtype=torch.long, device=self.device
+            )
+
+            loss = torch.nn.functional.cross_entropy(logits, targets)
+
+            self.scaler.scale(loss).backward()
+            self.scaler.step(self.optimizer)
+            self.scaler.update()
+
+        self.context_model.model.eval()
+        logger.debug("Training batch loss: %.4f", loss.item())
+
+    def _train_on_batch_cuis(self) -> None:
+        """Train on a batch of CUI-based tuples.
+
+        Runs a contrastive forward pass through the context encoder, computes
+        cross-entropy loss over one positive and k negative CUI embeddings, and
+        performs a single optimizer step.
+
         Args:
-            ents (list[MutableEntity]): The entities to train on.
-            doc (MutableDocument): The document the entities were detected in.
+            training_batch (list[tuple]): Each element is either
+                (doc, entity, positive_cui_idx)
+                or (doc, entity, positive_cui_idx, all_positive_cui_idxs).
         """
-        detected_context_vectors = self._get_context_vectors(
-            doc, entities, self.cnf_l.context_window_size
+        if self.training_batch == []:
+            return
+
+        positive_cui_idxs = [sample[2] for sample in self.training_batch]
+        if len(self.training_batch[0]) >= 4:
+            all_positive_cui_idxs_per_row = [
+                sample[3] for sample in self.training_batch
+            ]
+        else:
+            all_positive_cui_idxs_per_row = [[pos_idx] for pos_idx in positive_cui_idxs]
+
+        self._train_on_batch_targets(
+            self.cui_context_matrix,
+            positive_cui_idxs,
+            all_positive_cui_idxs_per_row,
         )
 
-        # score all detected contexts vs all names
-        names_scores = detected_context_vectors @ self.names_context_matrix.T
-        sorted_indices = torch.argsort(names_scores, dim=1, descending=True)
+    def _train_on_batch_names(self) -> None:
+        """Train on a batch of 
+        (doc, entity, positive_name_idx, all_positive_name_idxs) tuples."""
+        if self.training_batch == []:
+            return
 
-        self._generate_negative_samples(sorted_indices, names_scores, positive_name_idxs)
+        positive_name_idxs = [sample[2] for sample in self.training_batch]
+        all_positive_name_idxs_per_row = [sample[3] for sample in self.training_batch]
 
+        self._train_on_batch_targets(
+            self.names_context_matrix,
+            positive_name_idxs,
+            all_positive_name_idxs_per_row,
+        )
 
-    def train(self, cui: str,
-                entity: MutableEntity,
-                doc: MutableDocument,
-                negative: bool = False,
-                names: Union[list[str], dict] = [],
-                per_doc_valid_token_cache: Optional[PerDocumentTokenCache] = None
-                ) -> None:
+    def train_on_batch(self) -> None:
+        """Train on the current batch, dispatching to names or CUI mode.
+
+        This should also be called manually at the end of training to flush any 
+        remaining samples that didn't fill a batch.
+
+        Args:
+            training_batch (list[tuple]):
+                Name mode: (doc, entity, positive_name_idx, all_positive_name_idxs)
+                CUI mode: (doc, entity, positive_cui_idx)
+                or (doc, entity, positive_cui_idx, all_positive_cui_idxs)
+        """
+        if self.training_batch == []:
+            return
+
+        tuple_lengths = {len(sample) for sample in self.training_batch}
+        if len(tuple_lengths) != 1:
+            raise ValueError(
+                "Mixed training batch formats detected. "
+                "Expected uniform tuples for names (len=4) or CUIs (len=3)."
+            )
+
+        sample_len = tuple_lengths.pop()
+        if sample_len == 4:
+            # A len=4 tuple is interpreted as name mode by default.
+            self._train_on_batch_names()
+            return
+        if sample_len == 3:
+            self._train_on_batch_cuis()
+            return
+
+        raise ValueError(
+            f"Unsupported training batch tuple size: {sample_len}. "
+            "Expected len=3 for CUIs or len=4 for names."
+        )
+
+    def train(
+        self,
+        cui: str,
+        entity: MutableEntity,
+        doc: MutableDocument,
+        negative: bool = False,
+        names: Union[list[str], dict] = [],
+        per_doc_valid_token_cache: Optional[PerDocumentTokenCache] = None,
+    ) -> None:
         """Train the linker.
 
         This simply trains the context model.
 
-        This will collect samples to train in batches. Once a batch is ready, the forward
-        pass will be done and gradients will be collected.
+        This will collect samples to train in batches. Once a batch is ready, the 
+        forward pass will be done and gradients will be collected.
 
         Args:
             cui (str): The ground truth label for the entity.
@@ -88,43 +299,102 @@ class TrainableEmbeddingLinker(Linker):
             doc (BaseDocument): The document within which we're working.
             negative (bool): To be ignored here.
             names (list[str]/dict):
-                Unused within the embedding linker, but required for the interface. 
-                Can be used to provide the names of the concept for which we're training.
+                Unused within the embedding linker, but required for the interface.
+                Used to provide the names of the concept for which we're training.
             per_doc_valid_token_cache (PerDocumentTokenCache):
-                Unused within the embedding linker, but required for the interface. 
-        """
-        """TODO: Ignore negative samples. If true throw a warning and skip.
-        Pre-process entity training sample.
-        Pre-process involves getting negative sampling done.
-        Add to batch. If batch is full or last entity of document, train on batch.
+                Unused within the embedding linker, but required for the interface.
         """
         if negative:
             logger.warning(
-                "Negative samples are not currently used in training the embedding linker. Skipping."
+                "Negative samples are not currently used in training the " \
+                "embedding linker. Skipping."
             )
             return
-        # all positive samples are trained on
-        positive_samples = self.cdb.cui2info[cui]["names"]
-        # atm training on all potential names for CUI, but this could be changed to a sampling approach if there are too many names per CUI
-        # as its unbalanced
-        # TODO: CHeck performance of sampling vs using all names
-        self.training_batch.extend((doc, entity, sample) for sample in positive_samples)
-        # if the batch is full, or it is the last entity of the document, train on the batch
-        if len(self.training_batch) >= self.cnf_l.training_batch_size or entity == doc.ner_ents[-1]:
-            self._train_on_batch(self.training_batch)
+        if self.cnf_l.train_on_names:
+            # Name mode: sample one positive name and keep all positive aliases
+            # for this CUI so aliases can be excluded from negatives.
+            positive_samples = self.cdb.cui2info[cui]["names"]
+            all_positive_name_idxs: list[int] = []
+            for pos_sample in positive_samples:
+                pos_idx = self._name_to_idx.get(pos_sample)
+                if pos_idx is not None:
+                    all_positive_name_idxs.append(pos_idx)
+            if not all_positive_name_idxs:
+                return
+            pos_idx = random.choice(all_positive_name_idxs)
+            self.training_batch.append((doc, entity, pos_idx, all_positive_name_idxs))
+        else:
+            # CUI mode: one positive CUI index per row.
+            positive_cui_idx = self._cui_to_idx.get(cui)
+            if positive_cui_idx is None:
+                return
+            self.training_batch.append((doc, entity, positive_cui_idx))
+        # Train as soon as the batch is full.
+        if len(self.training_batch) >= self.cnf_l.training_batch_size:
+            self.train_on_batch()
             self.training_batch = []
-        if self.number_of_batches > self.cnf_l.embed_per_n_batches:
+            self.number_of_batches += 1
+        # If you've got as many batches as you want before re-embedding, 
+        # then do it and reset the counter.
+        if (
+            self.cnf_l.embed_per_n_batches > 0
+            and self.number_of_batches > self.cnf_l.embed_per_n_batches
+        ):
+            print(
+                "Re-embedding names and CUIs after training on {} batches.".format(
+                    self.number_of_batches
+                )
+            )
+            self.refresh_structure()
+            # Always refresh both embeddings to keep CDB and embeddings in sync.
+            # Inference always uses both names_context_matrix and cui_context_matrix.
+            # And inference is called during the cat.trainer.train() loop
             self.context_model.embed_names()
+            self.context_model.embed_cuis()
+            self._names_context_matrix = None
+            self._cui_context_matrix = None
             self.number_of_batches = 0
-
 
     @classmethod
     def create_new_component(
-		cls,
-		cnf: ComponentConfig,
-		tokenizer: BaseTokenizer,
-		cdb: CDB,
-		vocab: Vocab,
-		model_load_path: Optional[str],
-	) -> "TrainableEmbeddingLinker":
+        cls,
+        cnf: ComponentConfig,
+        tokenizer: BaseTokenizer,
+        cdb: CDB,
+        vocab: Vocab,
+        model_load_path: Optional[str],
+    ) -> "TrainableEmbeddingLinker":
         return cls(cdb, cdb.config)
+
+    def serialise_to(self, folder_path: str) -> None:
+        # Ensure final partial batch is not dropped before saving model state.
+        logger.info("Flushing final training batch before saving model.")
+        logger.info("This is grandfathered in from trainer.py restraints.")
+        self.train_on_batch()
+
+        os.makedirs(folder_path, exist_ok=True)
+        model_folder = os.path.join(folder_path, self._MODEL_FOLDER_NAME)
+        os.makedirs(model_folder, exist_ok=True)
+
+        torch.save(
+            self.context_model.model.state_dict(),
+            os.path.join(model_folder, self._MODEL_STATE_FILE_NAME),
+        )
+
+    @classmethod
+    def deserialise_from(
+        cls, folder_path: str, **init_kwargs
+    ) -> "TrainableEmbeddingLinker":
+        cdb = init_kwargs["cdb"]
+        linker = cls(cdb, cdb.config)
+
+        model_state_path = os.path.join(
+            folder_path, cls._MODEL_FOLDER_NAME, cls._MODEL_STATE_FILE_NAME
+        )
+        if os.path.exists(model_state_path):
+            state_dict = torch.load(model_state_path, map_location=linker.device)
+            linker.context_model.model.load_state_dict(state_dict)
+
+        linker._names_context_matrix = None
+        linker._cui_context_matrix = None
+        return linker

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
@@ -1,0 +1,130 @@
+from typing import Optional, Union
+from torch import Tensor
+from medcat.cdb import CDB
+from medcat.config.config import Config, ComponentConfig
+from medcat.components.linking.vector_context_model import PerDocumentTokenCache
+from medcat.tokenizing.tokenizers import BaseTokenizer
+from medcat.tokenizing.tokens import MutableDocument, MutableEntity
+from medcat.vocab import Vocab
+from medcat_embedding_linker.embedding_linker import Linker
+import logging
+import torch
+
+logger = logging.getLogger(__name__)
+
+class TrainableEmbeddingLinker(Linker):
+    """Trainable variant of the embedding linker.
+	This class inherits inference and embedding behavior from Linker and provides
+	method hooks for online/offline training.
+	"""
+    name = "embedding_linker"
+
+    def __init__(self, cdb: CDB, config: Config) -> None:
+        super().__init__(cdb, config)
+        self.is_training = False
+
+    def _generate_negative_samples(self, candidate_indices: Tensor, names_scores: Tensor, positive_name_idxs: list[int]) -> list[str]:
+        """Generate negative samples for a given entity and its true CUI.
+        Args:
+            candidate_indices (Tensor): The indices of the candidate CUIs.
+            names_scores (Tensor): The scores for each name.
+            gold_cui_idx (int): The index of the ground truth CUI.
+        Returns:
+            list[str]: A list of negative sample CUIs.
+        """
+        k = self.cnf_l.negative_sampling_k
+        temperature = self.cnf_l.negative_sampling_temperature
+
+        # Gather scores for the sorted candidates
+        candidate_scores = names_scores[candidate_indices]
+
+        # Temperature scaling
+        probs = torch.softmax(candidate_scores / temperature, dim=0)
+
+        # Sample negatives
+        sampled_positions = torch.multinomial(
+            probs,
+            num_samples=min(k, len(candidate_indices)),
+            replacement=False
+        )
+
+        negative_indices = candidate_indices[sampled_positions]
+        return negative_indices
+
+    def _train_on_batch(self, entities: list[MutableEntity], doc: MutableDocument, positive_name_idxs: list[int]) -> None:
+        """Train on a batch of entities and their corresponding document.
+        Args:
+            ents (list[MutableEntity]): The entities to train on.
+            doc (MutableDocument): The document the entities were detected in.
+        """
+        detected_context_vectors = self._get_context_vectors(
+            doc, entities, self.cnf_l.context_window_size
+        )
+
+        # score all detected contexts vs all names
+        names_scores = detected_context_vectors @ self.names_context_matrix.T
+        sorted_indices = torch.argsort(names_scores, dim=1, descending=True)
+
+        self._generate_negative_samples(sorted_indices, names_scores, positive_name_idxs)
+
+
+    def train(self, cui: str,
+                entity: MutableEntity,
+                doc: MutableDocument,
+                negative: bool = False,
+                names: Union[list[str], dict] = [],
+                per_doc_valid_token_cache: Optional[PerDocumentTokenCache] = None
+                ) -> None:
+        """Train the linker.
+
+        This simply trains the context model.
+
+        This will collect samples to train in batches. Once a batch is ready, the forward
+        pass will be done and gradients will be collected.
+
+        Args:
+            cui (str): The ground truth label for the entity.
+            entity (BaseEntity): The entity we're at.
+            doc (BaseDocument): The document within which we're working.
+            negative (bool): To be ignored here.
+            names (list[str]/dict):
+                Unused within the embedding linker, but required for the interface. 
+                Can be used to provide the names of the concept for which we're training.
+            per_doc_valid_token_cache (PerDocumentTokenCache):
+                Unused within the embedding linker, but required for the interface. 
+        """
+        """TODO: Ignore negative samples. If true throw a warning and skip.
+        Pre-process entity training sample.
+        Pre-process involves getting negative sampling done.
+        Add to batch. If batch is full or last entity of document, train on batch.
+        """
+        if negative:
+            logger.warning(
+                "Negative samples are not currently used in training the embedding linker. Skipping."
+            )
+            return
+        # all positive samples are trained on
+        positive_samples = self.cdb.cui2info[cui]["names"]
+        # atm training on all potential names for CUI, but this could be changed to a sampling approach if there are too many names per CUI
+        # as its unbalanced
+        # TODO: CHeck performance of sampling vs using all names
+        self.training_batch.extend((doc, entity, sample) for sample in positive_samples)
+        # if the batch is full, or it is the last entity of the document, train on the batch
+        if len(self.training_batch) >= self.cnf_l.training_batch_size or entity == doc.ner_ents[-1]:
+            self._train_on_batch(self.training_batch)
+            self.training_batch = []
+        if self.number_of_batches > self.cnf_l.embed_per_n_batches:
+            self.context_model.embed_names()
+            self.number_of_batches = 0
+
+
+    @classmethod
+    def create_new_component(
+		cls,
+		cnf: ComponentConfig,
+		tokenizer: BaseTokenizer,
+		cdb: CDB,
+		vocab: Vocab,
+		model_load_path: Optional[str],
+	) -> "TrainableEmbeddingLinker":
+        return cls(cdb, cdb.config)

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
@@ -28,6 +28,8 @@ class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
     _MODEL_STATE_FILE_NAME = "model_state.pt"
 
     def __init__(self, cdb: CDB, config: Config) -> None:
+        if not isinstance(config.components.linking, EmbeddingLinking):
+            raise TypeError("Linking config must be an EmbeddingLinking instance")
         self.cnf_l: EmbeddingLinking = config.components.linking
         # these by default are True, and 0
         # so a projection layer is used, but only the projection is trained

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
@@ -203,11 +203,6 @@ class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
         Runs a contrastive forward pass through the context encoder, computes
         cross-entropy loss over one positive and k negative CUI embeddings, and
         performs a single optimizer step.
-
-        Args:
-            training_batch (list[tuple]): Each element is either
-                (doc, entity, positive_cui_idx)
-                or (doc, entity, positive_cui_idx, all_positive_cui_idxs).
         """
         if self.training_batch == []:
             return
@@ -251,7 +246,6 @@ class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
             training_batch (list[tuple]):
                 Name mode: (doc, entity, positive_name_idx, all_positive_name_idxs)
                 CUI mode: (doc, entity, positive_cui_idx)
-                or (doc, entity, positive_cui_idx, all_positive_cui_idxs)
         """
         if self.training_batch == []:
             return

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
@@ -370,10 +370,6 @@ class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
         return cls(cdb, cdb.config)
 
     def serialise_to(self, folder_path: str) -> None:
-        # Ensure final partial batch is not dropped before saving model state.
-        logger.info("Flushing final training batch before saving model.")
-        logger.info("This is grandfathered in from trainer.py restraints.")
-
         os.makedirs(folder_path, exist_ok=True)
         model_folder = os.path.join(folder_path, self._MODEL_FOLDER_NAME)
         os.makedirs(model_folder, exist_ok=True)

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
@@ -1,4 +1,5 @@
 from typing import Optional, Union
+from medcat_embedding_linker.config import EmbeddingLinking
 from torch import Tensor
 from medcat.cdb import CDB
 from medcat.config.config import Config, ComponentConfig
@@ -27,12 +28,12 @@ class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
     _MODEL_STATE_FILE_NAME = "model_state.pt"
 
     def __init__(self, cdb: CDB, config: Config) -> None:
-        linking_cfg = config.components.linking
+        self.cnf_l: EmbeddingLinking = config.components.linking
         # these by default are True, and 0
         # so a projection layer is used, but only the projection is trained
         model_init_kwargs = {
-            "use_projection_layer": linking_cfg.use_projection_layer,
-            "top_n_layers_to_unfreeze": linking_cfg.top_n_layers_to_unfreeze,
+            "use_projection_layer": self.cnf_l.use_projection_layer,
+            "top_n_layers_to_unfreeze": self.cnf_l.top_n_layers_to_unfreeze,
         }
         super().__init__(
             cdb,
@@ -42,7 +43,7 @@ class TrainableEmbeddingLinker(Linker, AbstractManualSerialisable):
         self.training_batch: list[tuple] = []
         self.number_of_batches = 0
         self.negative_sampling_candidate_pool_size = (
-            linking_cfg.negative_sampling_candidate_pool_size
+            self.cnf_l.negative_sampling_candidate_pool_size
         )
         self.scaler = torch.amp.GradScaler()  # for FP16 training stability
         self.optimizer = torch.optim.AdamW(

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/transformer_context_model.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/transformer_context_model.py
@@ -1,143 +1,380 @@
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Iterator, Optional, Union
+from medcat.storage.serialisables import AbstractSerialisable
+from torch import Tensor, nn
+from transformers import AutoModel, AutoTokenizer
+from tqdm import tqdm
 import json
+import logging
+import math
 import torch
 import torch.nn.functional as F
-from torch import Tensor, nn
-from transformers import AutoModel
+
+logger = logging.getLogger(__name__)
+
 
 class ModelForEmbeddingLinking(nn.Module):
-	"""Wrapper around a Hugging Face transformer for embedding-based linking.
+    """Wrapper around a Hugging Face transformer for embedding-based linking.
 
-	The model applies mean pooling over token embeddings, optionally projects the
-	pooled vector, and L2 normalizes the final embedding.
-	"""
+    The model applies mean pooling over token embeddings, optionally projects the
+    pooled vector, and L2 normalizes the final embedding.
+    """
 
-	def __init__(
-		self,
-		embedding_model_name: str,
-		use_projection_layer: bool = False,
-		top_n_layers_to_unfreeze: int = -1,
-		device: Optional[Union[str, torch.device]] = None,
-	) -> None:
-		super().__init__()
-		self.language_model = AutoModel.from_pretrained(embedding_model_name)
-		self.base_model_name = self.language_model.name_or_path
+    def __init__(
+        self,
+        embedding_model_name: str,
+        use_projection_layer: bool = False,
+        top_n_layers_to_unfreeze: int = -1,
+        device: Optional[Union[str, torch.device]] = None,
+    ) -> None:
+        super().__init__()
+        self.language_model = AutoModel.from_pretrained(embedding_model_name)
+        self.base_model_name = self.language_model.name_or_path
 
-		self.use_projection_layer = use_projection_layer
-		self.top_n_layers_to_unfreeze = top_n_layers_to_unfreeze
+        self.use_projection_layer = use_projection_layer
+        self.top_n_layers_to_unfreeze = top_n_layers_to_unfreeze
 
-		hidden_size = self.language_model.config.hidden_size
-		if self.use_projection_layer:
-			self.projection_layer = nn.Linear(hidden_size, hidden_size)
+        hidden_size = self.language_model.config.hidden_size
+        if self.use_projection_layer:
+            self.projection_layer = nn.Linear(hidden_size, hidden_size)
 
-		self._freeze_all_parameters()
-		self._unfreeze_top_n_lm_layers(self.top_n_layers_to_unfreeze)
+        self._freeze_all_parameters()
+        self.unfreeze_top_n_lm_layers(self.top_n_layers_to_unfreeze)
 
-		target_device = self._resolve_device(device)
-		self.to(target_device)
+        target_device = self._resolve_device(device)
+        self.to(target_device)
 
-	@staticmethod
-	def _resolve_device(device: Optional[Union[str, torch.device]]) -> torch.device:
-		if device is None:
-			return torch.device("cuda" if torch.cuda.is_available() else "cpu")
-		return torch.device(device)
+    @staticmethod
+    def _resolve_device(device: Optional[Union[str, torch.device]]) -> torch.device:
+        if device is None:
+            return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        return torch.device(device)
 
-	@property
-	def device(self) -> torch.device:
-		return next(self.parameters()).device
+    @property
+    def device(self) -> torch.device:
+        return next(self.parameters()).device
 
-	@staticmethod
-	def mean_pooling(model_output, attention_mask: Tensor) -> Tensor:
-		token_embeddings = model_output.last_hidden_state
-		input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
-		summed = torch.sum(token_embeddings * input_mask_expanded, dim=1)
-		counts = torch.clamp(input_mask_expanded.sum(dim=1), min=1e-9)
-		return summed / counts
+    @staticmethod
+    def masked_mean_pooling(token_embeddings: Tensor, mask: Tensor) -> Tensor:
+        mask = mask.unsqueeze(-1).float()
+        summed = torch.sum(token_embeddings * mask, dim=1)
+        counts = torch.clamp(mask.sum(dim=1), min=1e-9)
+        return summed / counts
 
-	def forward(self, **inputs) -> Tensor:
-		model_output = self.language_model(**inputs)
-		sentence_embeddings = self.mean_pooling(model_output, inputs["attention_mask"])
-		if self.use_projection_layer:
-			sentence_embeddings = self.projection_layer(sentence_embeddings)
-		return F.normalize(sentence_embeddings, p=2, dim=1)
+    def forward(self, **inputs) -> Tensor:
+        # Don't pass the mention_mask to the language model if it does exist
+        mention_mask = inputs.pop("mention_mask", None)
+        model_output = self.language_model(**inputs)
 
-	def _freeze_all_parameters(self) -> None:
-		for param in self.language_model.parameters():
-			param.requires_grad = False
+        pooling_mask = (
+            mention_mask if mention_mask is not None else inputs["attention_mask"]
+        )
+        sentence_embeddings = self.masked_mean_pooling(
+            model_output.last_hidden_state, pooling_mask
+        )
 
-		if self.use_projection_layer:
-			for param in self.projection_layer.parameters():
-				param.requires_grad = True
+        if self.use_projection_layer:
+            sentence_embeddings = self.projection_layer(sentence_embeddings)
+        return F.normalize(sentence_embeddings, p=2, dim=1)
 
-	def _unfreeze_top_n_lm_layers(self, n: int) -> None:
-		# train all LM layers - each layer requires more data
-		if n == -1:
-			for param in self.language_model.parameters():
-				param.requires_grad = True
-			return
+    def _freeze_all_parameters(self) -> None:
+        for param in self.language_model.parameters():
+            param.requires_grad = False
 
-		# keep LM fully frozen - better with less data
-		if n == 0:
-			return
+        if self.use_projection_layer:
+            for param in self.projection_layer.parameters():
+                param.requires_grad = True
 
-		# BERT-likes
-		if hasattr(self.language_model, "encoder") and hasattr(self.language_model.encoder, "layer"):
-			layers = self.language_model.encoder.layer
-		# DistilBERT-likes
-		elif hasattr(self.language_model, "transformer") and hasattr(self.language_model.transformer, "layer"):
-			layers = self.language_model.transformer.layer
-		else:
-			raise ValueError("Unsupported LM architecture for layer unfreezing.")
+    def unfreeze_top_n_lm_layers(self, n: int) -> None:
+        # train all LM layers - each layer requires more data
+        if n == -1:
+            for param in self.language_model.parameters():
+                param.requires_grad = True
+            return
 
-		total_layers = len(layers)
-		n = min(n, total_layers)
-		for layer in layers[-n:]:
-			for param in layer.parameters():
-				param.requires_grad = True
+        # keep LM fully frozen - better with less data
+        if n == 0:
+            return
 
-	def save_pretrained(self, save_directory: Union[str, Path]) -> None:
-		save_path = Path(save_directory)
-		save_path.mkdir(parents=True, exist_ok=True)
+        # BERT-likes
+        if hasattr(self.language_model, "encoder") and hasattr(
+            self.language_model.encoder, "layer"
+        ):
+            layers = self.language_model.encoder.layer
+        # DistilBERT-likes
+        elif hasattr(self.language_model, "transformer") and hasattr(
+            self.language_model.transformer, "layer"
+        ):
+            layers = self.language_model.transformer.layer
+        else:
+            raise ValueError("Unsupported LM architecture for layer unfreezing.")
 
-		torch.save(self.state_dict(), save_path / "pytorch_model.bin")
+        total_layers = len(layers)
+        n = min(n, total_layers)
+        for layer in layers[-n:]:
+            for param in layer.parameters():
+                param.requires_grad = True
 
-		config = {
-			"embedding_model_name": self.base_model_name,
-			"use_projection_layer": self.use_projection_layer,
-			"top_n_layers_to_unfreeze": self.top_n_layers_to_unfreeze,
-		}
-		with open(save_path / "config.json", "w", encoding="utf-8") as f:
-			json.dump(config, f, indent=2)
+    def save_pretrained(self, save_directory: Union[str, Path]) -> None:
+        save_path = Path(save_directory)
+        save_path.mkdir(parents=True, exist_ok=True)
 
-	@classmethod
-	def from_pretrained(
-		cls,
-		path_or_model_name: Union[str, Path],
-		device: Optional[Union[str, torch.device]] = None,
-		**kwargs,
-	) -> "ModelForEmbeddingLinking":
-		path = Path(path_or_model_name)
-		config_path = path / "config.json"
-		weights_path = path / "pytorch_model.bin"
-		target_device = cls._resolve_device(device)
+        torch.save(self.state_dict(), save_path / "pytorch_model.bin")
 
-		# Local saved wrapper model.
-		if config_path.exists() and weights_path.exists():
-			with open(config_path, encoding="utf-8") as f:
-				config = json.load(f)
+        config = {
+            "embedding_model_name": self.base_model_name,
+            "use_projection_layer": self.use_projection_layer,
+            "top_n_layers_to_unfreeze": self.top_n_layers_to_unfreeze,
+        }
+        with open(save_path / "config.json", "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2)
 
-			config.update(kwargs)
-			model = cls(**config)
-			state_dict = torch.load(weights_path, map_location="cpu")
-			model.load_state_dict(state_dict)
-			model.to(target_device)
-			return model
+    @classmethod
+    def from_pretrained(
+        cls,
+        path_or_model_name: Union[str, Path],
+        device: Optional[Union[str, torch.device]] = None,
+        **kwargs,
+    ) -> "ModelForEmbeddingLinking":
+        path = Path(path_or_model_name)
+        config_path = path / "config.json"
+        weights_path = path / "pytorch_model.bin"
+        target_device = cls._resolve_device(device)
 
-		# Hugging Face model id/path.
-		model = cls(
-			embedding_model_name=str(path_or_model_name),
-			device=target_device,
-			**kwargs,
-		)
-		return model
+        # Local saved wrapper model.
+        if config_path.exists() and weights_path.exists():
+            with open(config_path, encoding="utf-8") as f:
+                config = json.load(f)
+
+            config.update(kwargs)
+            model = cls(**config)
+            state_dict = torch.load(weights_path, map_location="cpu")
+            model.load_state_dict(state_dict)
+            model.to(target_device)
+            return model
+
+        # Hugging Face model id/path.
+        model = cls(
+            embedding_model_name=str(path_or_model_name),
+            device=target_device,
+            **kwargs,
+        )
+        return model
+
+
+class ContextModel(AbstractSerialisable):
+    """Encapsulates embedding model/tokenizer loading and CDB embedding creation."""
+
+    def __init__(
+        self,
+        cdb,
+        linking_config,
+        separator: str,
+        model_init_kwargs: Optional[dict[str, Any]] = None,
+    ) -> None:
+        self.cdb = cdb
+        self.cnf_l = linking_config
+        self.separator = separator
+        self._model_init_kwargs = dict(model_init_kwargs or {})
+        self.max_length = self.cnf_l.max_token_length
+        self.device = torch.device(
+            self.cnf_l.gpu_device or ("cuda" if torch.cuda.is_available() else "cpu")
+        )
+        self._refresh_cdb_keys()
+        self._cui_keys = list(self.cdb.cui2info)
+        self._loaded_model_source: Optional[str] = None
+        self._loaded_model_init_kwargs: Optional[dict[str, Any]] = None
+        self.load_transformers(self.cnf_l.embedding_model_name)
+
+    def _batch_data(self, data, batch_size=512) -> Iterator[list]:
+        for i in range(0, len(data), batch_size):
+            yield data[i : i + batch_size]
+
+    def _refresh_cdb_keys(self) -> None:
+        """Refresh key caches from current CDB state.
+
+        This is required after in initialisation and for training-time CDB
+        mutations where new names/CUIs be introduced.
+        """
+        self._name_keys = list(self.cdb.name2info)
+        self._cui_keys = list(self.cdb.cui2info)
+
+    @staticmethod
+    def _resolve_model_source(path_or_model_name: Union[str, Path]) -> str:
+        """Return local absolute path if it exists, otherwise keep HF model id."""
+        candidate = Path(path_or_model_name).expanduser()
+        if candidate.exists():
+            return str(candidate.resolve())
+        return str(path_or_model_name)
+
+    def _get_model_init_kwargs(self) -> dict[str, Any]:
+        """Build kwargs passed to ModelForEmbeddingLinking.from_pretrained."""
+        return dict(self._model_init_kwargs)
+
+    def load_transformers(self, embedding_model_name: Union[str, Path]) -> None:
+        """Load tokenizer/model from local path or Hugging Face model id."""
+        model_source = self._resolve_model_source(embedding_model_name)
+        model_init_kwargs = self._get_model_init_kwargs()
+        if (
+            not hasattr(self, "model")
+            or not hasattr(self, "tokenizer")
+            or model_source != self._loaded_model_source
+            or model_init_kwargs != self._loaded_model_init_kwargs
+        ):
+            self.cnf_l.embedding_model_name = str(embedding_model_name)
+            self.tokenizer = AutoTokenizer.from_pretrained(model_source)
+            self.model = ModelForEmbeddingLinking.from_pretrained(
+                model_source, **model_init_kwargs
+            )
+            self.model.eval()
+            self.device = torch.device(
+                self.cnf_l.gpu_device
+                or ("cuda" if torch.cuda.is_available() else "cpu")
+            )
+            self.model.to(self.device)
+            self._loaded_model_source = model_source
+            self._loaded_model_init_kwargs = model_init_kwargs
+            logger.debug(
+                "Loaded embedding model: %s (resolved source: %s) with kwargs=%s " \
+				"on device: %s",
+                embedding_model_name,
+                model_source,
+                model_init_kwargs,
+                self.device,
+            )
+
+    def _build_mention_mask_from_char_spans(
+        self,
+        batch_dict: dict[str, Tensor],
+        mention_char_spans: list[tuple[int, int]],
+        device: torch.device,
+    ) -> Tensor:
+        """
+        Convert character-level mention spans into a token-level mask.
+
+        Args:
+                batch_dict: tokenizer output with 'offset_mapping'
+                mention_char_spans: list of (start_char, end_char) per example
+                device: torch device
+
+        Returns:
+                mask: [batch_size, seq_len] float Tensor, 1.0 for mention tokens, 
+                0.0 otherwise
+        """
+        offset_mapping = batch_dict["offset_mapping"]  # [B, max_token_length, 2]
+        batch_size, seq_len, _ = offset_mapping.shape
+        mask = torch.zeros((batch_size, seq_len), dtype=torch.float32, device=device)
+
+        for i, (mention_start, mention_end) in enumerate(mention_char_spans):
+            # For each token in the sequence
+            for j in range(seq_len):
+                token_start, token_end = offset_mapping[i, j].tolist()
+                # Skip padding tokens
+                if token_end == 0 and token_start == 0:
+                    continue
+                # Check if token overlaps mention span
+                if token_end > mention_start and token_start < mention_end:
+                    mask[i, j] = 1.0
+
+        return mask
+
+    def embed(
+        self,
+        to_embed: list[str],
+        mention_spans: Optional[list[tuple[int, int]]] = None,
+        device: Optional[torch.device] = None,
+    ) -> Tensor:
+        """Embed a list of input strings."""
+        target_device = device or self.device
+        # we don't need offset mapping when just embedding potential labels
+        need_offsets_mapping = (
+            self.cnf_l.use_mention_attention and mention_spans is not None
+        )
+
+        batch_dict = self.tokenizer(
+            to_embed,
+            max_length=self.max_length,
+            padding=True,
+            truncation=True,
+            return_tensors="pt",
+            return_offsets_mapping=need_offsets_mapping,
+        ).to(target_device)
+
+        mention_mask = None
+        if mention_spans is not None:
+            mention_mask = self._build_mention_mask_from_char_spans(
+                batch_dict,
+                mention_spans,
+                target_device,
+            )
+            batch_dict["mention_mask"] = mention_mask
+
+        # Keep tokenizer-only metadata out of model forward kwargs.
+        batch_dict.pop("offset_mapping", None)
+
+        outputs = self.model(**batch_dict)
+        return outputs.half()
+
+    def embed_cuis(
+        self, embedding_model_name: Optional[Union[str, Path]] = None
+    ) -> None:
+        """Create embeddings for each CUI's longest name and store in CDB.
+
+        If ``embedding_model_name`` is provided, switch/load that model first.
+        Otherwise, reuse the currently loaded model (training-friendly default).
+        """
+        target_model = embedding_model_name or self.cnf_l.embedding_model_name
+        self._refresh_cdb_keys()  # ensure _cui_keys is up to date before embedding
+        self.load_transformers(target_model)
+
+        # TODO: test preffered names instead of longest names
+        # cui_names = [
+        # 	max(self.cdb.cui2info[cui]["names"], key=len) for cui in self._cui_keys
+        # ]
+        cui_names = [self.cdb.get_name(cui) for cui in self._cui_keys]
+        total_batches = math.ceil(len(cui_names) / self.cnf_l.embedding_batch_size)
+        all_embeddings = []
+        for names in tqdm(
+            self._batch_data(cui_names, self.cnf_l.embedding_batch_size),
+            total=total_batches,
+            desc="Embedding cuis' preferred names",
+        ):
+            with torch.no_grad():
+                names_to_embed = [name.replace(self.separator, " ") for name in names]
+                embeddings = self.embed(names_to_embed, device=self.device)
+                all_embeddings.append(embeddings.cpu())
+
+        all_embeddings_matrix = torch.cat(all_embeddings, dim=0)
+        self.cdb.addl_info["cui_embeddings"] = all_embeddings_matrix
+        logger.debug("Embedding cui names done, total: %d", len(cui_names))
+
+    def embed_names(
+        self, embedding_model_name: Optional[Union[str, Path]] = None
+    ) -> None:
+        """Create embeddings for all names and store in CDB.
+
+        If ``embedding_model_name`` is provided, switch/load that model first.
+        Otherwise, reuse the currently loaded model (training-friendly default).
+        """
+        target_model = embedding_model_name or self.cnf_l.embedding_model_name
+        self._refresh_cdb_keys()  # ensure _cui_keys is up to date before embedding
+        self.load_transformers(target_model)
+
+        names = self._name_keys
+        total_batches = math.ceil(len(names) / self.cnf_l.embedding_batch_size)
+        all_embeddings = []
+        for batch_names in tqdm(
+            self._batch_data(names, self.cnf_l.embedding_batch_size),
+            total=total_batches,
+            desc="Embedding names",
+        ):
+            with torch.no_grad():
+                names_to_embed = [
+                    name.replace(self.separator, " ") for name in batch_names
+                ]
+                embeddings = self.embed(names_to_embed, device=self.device)
+                all_embeddings.append(embeddings.cpu())
+
+        all_embeddings_matrix = torch.cat(all_embeddings, dim=0)
+        self.cdb.addl_info["name_embeddings"] = all_embeddings_matrix
+        logger.debug("Embedding names done, total: %d", len(names))

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/transformer_context_model.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/transformer_context_model.py
@@ -327,10 +327,6 @@ class ContextModel(AbstractSerialisable):
         self._refresh_cdb_keys()  # ensure _cui_keys is up to date before embedding
         self.load_transformers(target_model)
 
-        # TODO: test preffered names instead of longest names
-        # cui_names = [
-        # 	max(self.cdb.cui2info[cui]["names"], key=len) for cui in self._cui_keys
-        # ]
         cui_names = [self.cdb.get_name(cui) for cui in self._cui_keys]
         total_batches = math.ceil(len(cui_names) / self.cnf_l.embedding_batch_size)
         all_embeddings = []

--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/transformer_context_model.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/transformer_context_model.py
@@ -1,0 +1,143 @@
+from pathlib import Path
+from typing import Optional, Union
+import json
+import torch
+import torch.nn.functional as F
+from torch import Tensor, nn
+from transformers import AutoModel
+
+class ModelForEmbeddingLinking(nn.Module):
+	"""Wrapper around a Hugging Face transformer for embedding-based linking.
+
+	The model applies mean pooling over token embeddings, optionally projects the
+	pooled vector, and L2 normalizes the final embedding.
+	"""
+
+	def __init__(
+		self,
+		embedding_model_name: str,
+		use_projection_layer: bool = False,
+		top_n_layers_to_unfreeze: int = -1,
+		device: Optional[Union[str, torch.device]] = None,
+	) -> None:
+		super().__init__()
+		self.language_model = AutoModel.from_pretrained(embedding_model_name)
+		self.base_model_name = self.language_model.name_or_path
+
+		self.use_projection_layer = use_projection_layer
+		self.top_n_layers_to_unfreeze = top_n_layers_to_unfreeze
+
+		hidden_size = self.language_model.config.hidden_size
+		if self.use_projection_layer:
+			self.projection_layer = nn.Linear(hidden_size, hidden_size)
+
+		self._freeze_all_parameters()
+		self._unfreeze_top_n_lm_layers(self.top_n_layers_to_unfreeze)
+
+		target_device = self._resolve_device(device)
+		self.to(target_device)
+
+	@staticmethod
+	def _resolve_device(device: Optional[Union[str, torch.device]]) -> torch.device:
+		if device is None:
+			return torch.device("cuda" if torch.cuda.is_available() else "cpu")
+		return torch.device(device)
+
+	@property
+	def device(self) -> torch.device:
+		return next(self.parameters()).device
+
+	@staticmethod
+	def mean_pooling(model_output, attention_mask: Tensor) -> Tensor:
+		token_embeddings = model_output.last_hidden_state
+		input_mask_expanded = attention_mask.unsqueeze(-1).expand(token_embeddings.size()).float()
+		summed = torch.sum(token_embeddings * input_mask_expanded, dim=1)
+		counts = torch.clamp(input_mask_expanded.sum(dim=1), min=1e-9)
+		return summed / counts
+
+	def forward(self, **inputs) -> Tensor:
+		model_output = self.language_model(**inputs)
+		sentence_embeddings = self.mean_pooling(model_output, inputs["attention_mask"])
+		if self.use_projection_layer:
+			sentence_embeddings = self.projection_layer(sentence_embeddings)
+		return F.normalize(sentence_embeddings, p=2, dim=1)
+
+	def _freeze_all_parameters(self) -> None:
+		for param in self.language_model.parameters():
+			param.requires_grad = False
+
+		if self.use_projection_layer:
+			for param in self.projection_layer.parameters():
+				param.requires_grad = True
+
+	def _unfreeze_top_n_lm_layers(self, n: int) -> None:
+		# train all LM layers - each layer requires more data
+		if n == -1:
+			for param in self.language_model.parameters():
+				param.requires_grad = True
+			return
+
+		# keep LM fully frozen - better with less data
+		if n == 0:
+			return
+
+		# BERT-likes
+		if hasattr(self.language_model, "encoder") and hasattr(self.language_model.encoder, "layer"):
+			layers = self.language_model.encoder.layer
+		# DistilBERT-likes
+		elif hasattr(self.language_model, "transformer") and hasattr(self.language_model.transformer, "layer"):
+			layers = self.language_model.transformer.layer
+		else:
+			raise ValueError("Unsupported LM architecture for layer unfreezing.")
+
+		total_layers = len(layers)
+		n = min(n, total_layers)
+		for layer in layers[-n:]:
+			for param in layer.parameters():
+				param.requires_grad = True
+
+	def save_pretrained(self, save_directory: Union[str, Path]) -> None:
+		save_path = Path(save_directory)
+		save_path.mkdir(parents=True, exist_ok=True)
+
+		torch.save(self.state_dict(), save_path / "pytorch_model.bin")
+
+		config = {
+			"embedding_model_name": self.base_model_name,
+			"use_projection_layer": self.use_projection_layer,
+			"top_n_layers_to_unfreeze": self.top_n_layers_to_unfreeze,
+		}
+		with open(save_path / "config.json", "w", encoding="utf-8") as f:
+			json.dump(config, f, indent=2)
+
+	@classmethod
+	def from_pretrained(
+		cls,
+		path_or_model_name: Union[str, Path],
+		device: Optional[Union[str, torch.device]] = None,
+		**kwargs,
+	) -> "ModelForEmbeddingLinking":
+		path = Path(path_or_model_name)
+		config_path = path / "config.json"
+		weights_path = path / "pytorch_model.bin"
+		target_device = cls._resolve_device(device)
+
+		# Local saved wrapper model.
+		if config_path.exists() and weights_path.exists():
+			with open(config_path, encoding="utf-8") as f:
+				config = json.load(f)
+
+			config.update(kwargs)
+			model = cls(**config)
+			state_dict = torch.load(weights_path, map_location="cpu")
+			model.load_state_dict(state_dict)
+			model.to(target_device)
+			return model
+
+		# Hugging Face model id/path.
+		model = cls(
+			embedding_model_name=str(path_or_model_name),
+			device=target_device,
+			**kwargs,
+		)
+		return model

--- a/medcat-plugins/embedding-linker/tests/__init__.py
+++ b/medcat-plugins/embedding-linker/tests/__init__.py
@@ -6,7 +6,8 @@ import shutil
 
 RESOURCES_PATH = os.path.join(os.path.dirname(__file__), "resources")
 EXAMPLE_MODEL_PACK_ZIP = os.path.join(RESOURCES_PATH, "mct2_model_pack.zip")
-UNPACKED_EXAMPLE_MODEL_PACK_PATH = os.path.join(RESOURCES_PATH, "mct2_model_pack")
+UNPACKED_EXAMPLE_MODEL_PACK_PATH = os.path.join(
+    RESOURCES_PATH, "mct2_model_pack")
 
 
 # unpack model pack at start so we can access stuff like Vocab

--- a/medcat-plugins/embedding-linker/tests/__init__.py
+++ b/medcat-plugins/embedding-linker/tests/__init__.py
@@ -6,19 +6,19 @@ import shutil
 
 RESOURCES_PATH = os.path.join(os.path.dirname(__file__), "resources")
 EXAMPLE_MODEL_PACK_ZIP = os.path.join(RESOURCES_PATH, "mct2_model_pack.zip")
-UNPACKED_EXAMPLE_MODEL_PACK_PATH = os.path.join(
-    RESOURCES_PATH, "mct2_model_pack")
+UNPACKED_EXAMPLE_MODEL_PACK_PATH = os.path.join(RESOURCES_PATH, "mct2_model_pack")
 
 
 # unpack model pack at start so we can access stuff like Vocab
 print("Unpacking included test model pack")
-shutil.unpack_archive(
-    EXAMPLE_MODEL_PACK_ZIP, UNPACKED_EXAMPLE_MODEL_PACK_PATH)
+shutil.unpack_archive(EXAMPLE_MODEL_PACK_ZIP, UNPACKED_EXAMPLE_MODEL_PACK_PATH)
 
 
 def _del_unpacked_model():
-    print("Cleaning up! Removing unpacked exmaple model pack:",
-          UNPACKED_EXAMPLE_MODEL_PACK_PATH)
+    print(
+        "Cleaning up! Removing unpacked exmaple model pack:",
+        UNPACKED_EXAMPLE_MODEL_PACK_PATH,
+    )
     shutil.rmtree(UNPACKED_EXAMPLE_MODEL_PACK_PATH)
 
 

--- a/medcat-plugins/embedding-linker/tests/helper.py
+++ b/medcat-plugins/embedding-linker/tests/helper.py
@@ -5,7 +5,6 @@ from medcat.config.config import Config, ComponentConfig
 
 
 class FakeCDB:
-
     def __init__(self, cnf: Config):
         self.config = cnf
         self.token_counts = {}
@@ -26,7 +25,7 @@ class FTokenizer:
 
 class ComponentInitTests:
     expected_def_components = 1
-    default = 'default'
+    default = "default"
     # these need to be specified when overriding
     comp_type: types.CoreComponentType
     default_cls: Type[types.BaseComponent]
@@ -38,19 +37,22 @@ class ComponentInitTests:
         cls.fcdb = FakeCDB(cls.cnf)
         cls.fvocab = FVocab()
         cls.vtokenizer = FTokenizer()
-        cls.comp_cnf: ComponentConfig = getattr(
-            cls.cnf.components, cls.comp_type.name)
+        cls.comp_cnf: ComponentConfig = getattr(cls.cnf.components, cls.comp_type.name)
         if isinstance(cls.default_creator, Type):
             cls._def_creator_name_opts = (cls.default_creator.__name__,)
         else:
             # classmethod
-            cls._def_creator_name_opts = (".".join((
-                # etiher class.method_name
-                cls.default_creator.__self__.__name__,
-                cls.default_creator.__name__)),
+            cls._def_creator_name_opts = (
+                ".".join(
+                    (
+                        # etiher class.method_name
+                        cls.default_creator.__self__.__name__,
+                        cls.default_creator.__name__,
+                    )
+                ),
                 # or just method_name
-                cls.default_creator.__name__
-                )
+                cls.default_creator.__name__,
+            )
 
     def test_has_default(self):
         avail_components = types.get_registered_components(self.comp_type)
@@ -58,8 +60,9 @@ class ComponentInitTests:
         name, cls_name = avail_components[0]
         # 1 name / cls name
         eq_name = [name == self.default for name, _ in avail_components]
-        eq_cls = [cls_name in self._def_creator_name_opts
-                  for _, cls_name in avail_components]
+        eq_cls = [
+            cls_name in self._def_creator_name_opts for _, cls_name in avail_components
+        ]
         self.assertEqual(sum(eq_name), 1)
         # NOTE: for NER both the default as well as the Dict based NER
         #       have the came class name, so may be more than 1
@@ -70,7 +73,12 @@ class ComponentInitTests:
     def test_can_create_def_component(self):
         component = types.create_core_component(
             self.comp_type,
-            self.default, self.cnf, self.vtokenizer, self.fcdb, self.fvocab, None)
-        self.assertIsInstance(component,
-                              runtime_checkable(types.BaseComponent))
+            self.default,
+            self.cnf,
+            self.vtokenizer,
+            self.fcdb,
+            self.fvocab,
+            None,
+        )
+        self.assertIsInstance(component, runtime_checkable(types.BaseComponent))
         self.assertIsInstance(component, self.default_cls)

--- a/medcat-plugins/embedding-linker/tests/test_embedding_linker.py
+++ b/medcat-plugins/embedding-linker/tests/test_embedding_linker.py
@@ -1,4 +1,5 @@
 from medcat_embedding_linker import embedding_linker
+from medcat_embedding_linker import trainable_embedding_linker
 from medcat.components import types
 from medcat.config import Config
 from medcat.data.entities import Entity
@@ -12,15 +13,19 @@ from .helper import ComponentInitTests
 
 from . import UNPACKED_EXAMPLE_MODEL_PACK_PATH
 
+
 class FakeDocument:
     linked_ents = []
     ner_ents = []
+
     def __init__(self, text):
         self.text = text
+
 
 class FakeTokenizer:
     def __call__(self, text: str) -> FakeDocument:
         return FakeDocument(text)
+
 
 class FakeCDB:
     def __init__(self, config: Config):
@@ -37,7 +42,7 @@ class FakeCDB:
 class EmbeddingLinkerInitTests(ComponentInitTests, unittest.TestCase):
     expected_def_components = len(DEF_LINKING)
     comp_type = types.CoreComponentType.linking
-    default = 'embedding_linker'
+    default = "embedding_linker"
     default_cls = embedding_linker.Linker
     default_creator = embedding_linker.Linker.create_new_component
     module = embedding_linker
@@ -57,6 +62,7 @@ class EmbeddingLinkerInitTests(ComponentInitTests, unittest.TestCase):
         registered_names = [name for name, _ in avail_components]
         self.assertIn("embedding_linker", registered_names)
 
+
 class NonTrainableEmbeddingLinkerTests(unittest.TestCase):
     cnf = Config()
     cnf.components.linking = embedding_linker.EmbeddingLinking()
@@ -71,6 +77,18 @@ class NonTrainableEmbeddingLinkerTests(unittest.TestCase):
         self.linker(doc)
 
 
+class TrainableEmbeddingLinkerTests(unittest.TestCase):
+    cnf = Config()
+    cnf.components.linking = embedding_linker.EmbeddingLinking()
+    cnf.components.linking.comp_name = (
+        trainable_embedding_linker.TrainableEmbeddingLinker.name
+    )
+    linker = trainable_embedding_linker.TrainableEmbeddingLinker(FakeCDB(cnf), cnf)
+
+    def test_linker_is_trainable(self):
+        self.assertIsInstance(self.linker, TrainableComponent)
+
+
 class EmbeddingModelDisambiguationTests(unittest.TestCase):
     PLACEHOLDER = "{SOME_PLACEHOLDER}"
     TEXT = f"""The issue has a lot to do with the {PLACEHOLDER}"""
@@ -81,7 +99,8 @@ class EmbeddingModelDisambiguationTests(unittest.TestCase):
         cls.model.config.components.linking = embedding_linker.EmbeddingLinking()
         cls.model._recreate_pipe()
         linker: embedding_linker.Linker = cls.model.pipe.get_component(
-            types.CoreComponentType.linking)
+            types.CoreComponentType.linking
+        )
         linker.create_embeddings()
         cls.linker = linker
 
@@ -89,14 +108,12 @@ class EmbeddingModelDisambiguationTests(unittest.TestCase):
         self.assertIsInstance(self.linker, embedding_linker.Linker)
 
     def assert_has_name(self, out_ents: dict[int, Entity], name: str):
-        self.assertTrue(
-            any(ent["source_value"] == name for ent in out_ents.values())
-        )
+        self.assertTrue(any(ent["source_value"] == name for ent in out_ents.values()))
 
     def test_does_disambiguation(self):
         used_names = 0
         for name, info in self.model.cdb.name2info.items():
-            if len(info['per_cui_status']) <= 1:
+            if len(info["per_cui_status"]) <= 1:
                 continue
             used_names += 1
             with self.subTest(name):
@@ -104,4 +121,3 @@ class EmbeddingModelDisambiguationTests(unittest.TestCase):
                 out_ents = self.model.get_entities(cur_text)["entities"]
                 self.assert_has_name(out_ents, name)
         self.assertGreater(used_names, 0)
-


### PR DESCRIPTION
Hihi,

Here's the PR for the trainable embedding linker as foretold by our ancestors.

I'll list the main parts of it here, then the performances.

1. Creates a new module `trainable_embedding_linker` that inherits from the `embedding_linker`. The only functionality in trainable version is that which is only used by it.
2. Split out the modelling functionality from the `embedding_linker` into the `transformer_context_model` module. This has two classes within it: `ContextModel` which handles all embedding tasks (`embed_cuis`...). `ModelForEmbeddingLinking` inherits from the transformers `nn.module` and is where the model logic is. It's largely a wrapper around the language model with a few choices of how to embed.
3. Added additional variables to the `config` these explain themselves, all of these are to do with training and effectively are trade offs between time / compute / performance.

Onto performances:

This is trained / tested with three datasets that all contain SNOMED CT labels. The SNOMED CT Entity Benchmark, Distemist, and COMETA. Due to this requiring training I have a train/test split of 80/20. With the implementation of cat.train at the time of making this I kind of built the training loop outside of the medcat library. 

Effectively it looks like this:

```
cat.trainer.train_supervised_raw(train_projects, test_size=0, nepochs=1)
cat._pipeline._components[-1].train_on_batch()
cat._pipeline._components[-1].refresh_structure()
cat._pipeline._components[-1].create_embeddings()
get_stats(cat=cat, data=test_projects, use_project_filters=False)
for i in range(7):
    cat.trainer.train_supervised_raw(train_projects, test_size=0, nepochs=1)
    cat._pipeline._components[-1].train_on_batch()
    cat._pipeline._components[-1].create_embeddings()
    get_stats(cat=cat, data=test_projects, use_project_filters=False)
```

Here's the baseline performance without training (which would be comparing to a normal embedding_linker):

Epoch: 0, Prec: 0.081820475543968, Rec: 0.3308877119673485, F1: 0.13119870535198244

Here's the best performance with a few hyperparams I've found to be optimal:

Epoch: 0, Prec: 0.11907464089601173, Rec: 0.5048605035481676, F1: 0.19269978201382124

These hyper-params I mention are, with a bit of commentary:

`cat.config.components.linking.embedding_model_name = "abhinand/MedEmbed-small-v0.1"`  (we default to "sentence-transformers/all-MiniLM-L6-v2" because it's kind of a standard, and it's small (6 layers). But MedEmbed in my experience is the best embedding I've found for medical stuff)
`context_window_size` = 35 (with more context performance should increase, if you use the `mention_mask`, the gains past 14 tokens is very marginal)
`cat._pipeline._components[-1].context_model.model.unfreeze_top_n_lm_layers(4)` (As you increase the number of layers the performance will increase, at the cost of storing more gradients and computational complexity. You will also transform the embedding space, requiring more data. I haven't gone beyond unfreezing four layers, because that's a redundant task at this point.)
`lr=1e-4, weight_decay=0.01` (These are hardcoded and it's TODO: it shouldn't be. Oops. If you're only training the linear projection layer you can set it as high as 1e-3. When you start affecting transformer layers it significantly impacts performance for the worse).
`cat._pipeline._components[-1].cnf_l.train_on_names = True` (You can train on cuis or all potential names. A full CDB is about 3 mil names, or 600k CUIs. Names performs slightly better, CUIs performs quite a bit faster. It's a one time cost for training a model, so something to consider`

Here's some earlier iterations performances:

Without mention_attention functionality:
`
Epoch: 0, Prec: 0.10870886017906067, Rec: 0.4608991494532199, F1: 0.17592386464826354
`
It performed best with smaller context windows (size 10).

An earlier experiment: Unfreezing layers (these were done without the COMETA dataset, so just Distemist and the Snomed_CT Benchmark):

ALL LAYERS FROZEN
`
Epoch: 0, Prec: 0.10861838458277627, Rec: 0.40456670917592763, F1: 0.17125743885040035
`
UNFREEZING TOP 1 LAYERS
`
Epoch: 0, Prec: 0.11208035088291403, Rec: 0.4174662941819507, F1: 0.1767163258223325
`
UNFREEZING TOP 2 LAYERS
`
Epoch: 0, Prec: 0.11370157819225252, Rec: 0.4235394145511964, F1: 0.17927559702835402
`
UNFREEZING TOP 4 LAYERS
`
Epoch: 0, Prec: 0.11482145768791782, Rec: 0.4276691364022835, F1: 0.18103758547997326
`
TODO:

1) Test saving and loading trained models perform the same as trained and tested from live.
2) Fix giving LR and weight decay config parameters.
3) Test on another embedding model (i.e. "sentence-transformers/all-MiniLM-L6-v2") - to check performances