### PR TITLE
build(medcat-deps-bump): CU-869crefj9 Fix version starting with 'v' when bumped

### DIFF
--- a/.github/scripts/bump_dependants.py
+++ b/.github/scripts/bump_dependants.py
@@ -106,7 +106,7 @@ def open_pr(branch: str, title: str, body: str, base: str = "main"):
 def main():
     args = parse_args()
     package = args.package
-    new_version = args.version
+    new_version = args.version.removeprefix("v")
     repo_root = Path(__file__).resolve().parents[2]
 
     run(["git", "config", "user.name", "github-actions[bot]"])


### PR DESCRIPTION
This was an oversight. Now itremoves the prefix of v if applicable.