### PR TITLE
bug(medcat-trainer): CU-869ctq789 Fix saving model packs

### DIFF
--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -1,8 +1,9 @@
 import logging
 import os
 from smtplib import SMTPException
-from tempfile import NamedTemporaryFile
+from tempfile import NamedTemporaryFile, TemporaryDirectory
 from typing import Any
+import shutil
 
 from background_task.models import Task, CompletedTask
 from django.contrib.auth.views import PasswordResetView
@@ -578,13 +579,35 @@ def save_models(request):
     p_id = request.data['project_id']
     project = ProjectAnnotateEntities.objects.get(id=p_id)
     cat = get_medcat(project=project)
+    from pathlib import Path
+    path = Path()
+    path.parent.mkdir()
 
     if project.concept_db is not None:
         # CDB / vocab based
         cat.cdb.save(project.concept_db.cdb_file.path, overwrite=True)
     else:
-        cat.save_model_pack(project.model_pack.path,
-                            add_hash_to_pack_name=True)
+        # NOTE: cannot overwrite, so working around
+        with TemporaryDirectory() as tmp_dir:
+            # making new folder name so that it's copied
+            # to the specific path rather than into the folder
+            temp_folder = os.path.join(tmp_dir, "model_copy")
+            shutil.move(project.model_pack.path, temp_folder)
+            try:
+                cat.save_model_pack(
+                    os.path.dirname(project.model_pack.path),
+                    pack_name=os.path.basename(project.model_pack.path),
+                    add_hash_to_pack_name=False)
+            except Exception as e:
+                logger.warning("Unable to save model pack. Restoring previous state")
+                if os.path.exists(project.model_pack.path):
+                    shutil.rmtree(project.model_pack.path)  # remove partial/corrupt output
+                # restore original
+                try:
+                    shutil.move(temp_folder, project.model_pack.path)
+                except Exception as restore_err:
+                    logger.error("Failed to restore model pack:", exc_info=restore_err)
+                raise
 
     return Response({'message': 'Models saved'})
 

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -584,6 +584,7 @@ def save_models(request):
         # CDB / vocab based
         cat.cdb.save(project.concept_db.cdb_file.path, overwrite=True)
     else:
+        # ModelPack based project
         _overwrite_model_pack(cat, project.model_pack.path)
 
     return Response({'message': 'Models saved'})

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -581,7 +581,7 @@ def save_models(request):
 
     if project.concept_db is not None:
         # CDB / vocab based
-        cat.cdb.save(project.concept_db.cdb_file.path)
+        cat.cdb.save(project.concept_db.cdb_file.path, overwrite=True)
     else:
         cat.save_model_pack(project.model_pack.path,
                             add_hash_to_pack_name=True)

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -579,37 +579,38 @@ def save_models(request):
     p_id = request.data['project_id']
     project = ProjectAnnotateEntities.objects.get(id=p_id)
     cat = get_medcat(project=project)
-    from pathlib import Path
-    path = Path()
-    path.parent.mkdir()
 
     if project.concept_db is not None:
         # CDB / vocab based
         cat.cdb.save(project.concept_db.cdb_file.path, overwrite=True)
     else:
-        # NOTE: cannot overwrite, so working around
-        with TemporaryDirectory() as tmp_dir:
-            # making new folder name so that it's copied
-            # to the specific path rather than into the folder
-            temp_folder = os.path.join(tmp_dir, "model_copy")
-            shutil.move(project.model_pack.path, temp_folder)
-            try:
-                cat.save_model_pack(
-                    os.path.dirname(project.model_pack.path),
-                    pack_name=os.path.basename(project.model_pack.path),
-                    add_hash_to_pack_name=False)
-            except Exception as e:
-                logger.warning("Unable to save model pack. Restoring previous state")
-                if os.path.exists(project.model_pack.path):
-                    shutil.rmtree(project.model_pack.path)  # remove partial/corrupt output
-                # restore original
-                try:
-                    shutil.move(temp_folder, project.model_pack.path)
-                except Exception as restore_err:
-                    logger.error("Failed to restore model pack:", exc_info=restore_err)
-                raise
+        _overwrite_model_pack(cat, project.model_pack.path)
 
     return Response({'message': 'Models saved'})
+
+
+def _overwrite_model_pack(cat, model_path: str):
+    # NOTE: cannot overwrite, so working around
+    with TemporaryDirectory() as tmp_dir:
+        # making new folder name so that it's copied
+        # to the specific path rather than into the folder
+        temp_folder = os.path.join(tmp_dir, "model_copy")
+        shutil.move(model_path, temp_folder)
+        try:
+            cat.save_model_pack(
+                os.path.dirname(model_path),
+                pack_name=os.path.basename(model_path),
+                add_hash_to_pack_name=False)
+        except Exception as e:
+            logger.warning("Unable to save model pack. Restoring previous state")
+            if os.path.exists(model_path):
+                shutil.rmtree(model_path)  # remove partial/corrupt output
+            # restore original
+            try:
+                shutil.move(temp_folder, model_path)
+            except Exception as restore_err:
+                logger.error("Failed to restore model pack:", exc_info=restore_err)
+            raise
 
 
 @api_view(http_method_names=['POST'])

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -603,7 +603,7 @@ def _overwrite_model_pack(cat, model_path: str):
                 pack_name=os.path.basename(model_path),
                 add_hash_to_pack_name=False)
         except Exception as e:
-            logger.warning("Unable to save model pack. Restoring previous state")
+            logger.warning("Unable to save model pack. Restoring previous state. Issue while saving model:", exc_info=e)
             if os.path.exists(model_path):
                 shutil.rmtree(model_path)  # remove partial/corrupt output
             # restore original

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -579,7 +579,11 @@ def save_models(request):
     project = ProjectAnnotateEntities.objects.get(id=p_id)
     cat = get_medcat(project=project)
 
-    cat.cdb.save(project.concept_db.cdb_file.path)
+    if project.concept_db is not None:
+        # CDB / vocab based
+        cat.cdb.save(project.concept_db.cdb_file.path)
+    else:
+        cat.save_model_pack(project.model_pack.path)
 
     return Response({'message': 'Models saved'})
 

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -592,6 +592,8 @@ def save_models(request):
 
 def _overwrite_model_pack(cat, model_path: str):
     # NOTE: cannot overwrite, so working around
+    #       currently CAT.save_model_pack does not provide a method to
+    #       allow overwriting an existing model pack
     with TemporaryDirectory() as tmp_dir:
         # making new folder name so that it's copied
         # to the specific path rather than into the folder

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -583,7 +583,8 @@ def save_models(request):
         # CDB / vocab based
         cat.cdb.save(project.concept_db.cdb_file.path)
     else:
-        cat.save_model_pack(project.model_pack.path)
+        cat.save_model_pack(project.model_pack.path,
+                            add_hash_to_pack_name=True)
 
     return Response({'message': 'Models saved'})
 


### PR DESCRIPTION
Hopefully this fixes:

https://discourse.cogstack.org/t/unable-to-save-model-from-trainer/378

The idea is to allow model pack based projects to overwrite their model packs as the CDB based ones were designed to.
Though notably without the `overwrite=True` option they, too, would probably have failed.

So this PR does the following:
- Creates a separate function to do the model pack overwriting if/when required
- Moves the old model pack to a temporary folder
  - Because the `CAT.save_model_pack` method doesn't allow (or delegate the allowing of) overwriting existing ifles
  - And if we just removed the previous file(s) I'd be afraid of leaving a state with a model pack path that refers to nothing
  - If all goes well, the copy is destroyed after
  - If something fails, attempt to move the old one back to its original location


