### PR TITLE
fix(medcat): CU-869cub2m7 Remove embedding linker optional extra from pyproject.toml

### DIFF
--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -116,10 +116,6 @@ rel_cat = [
   "scikit-learn>=1.1.3,<2.0",
   "torch>=2.4.0,<3.0",
 ]
-embed_linker = [
-  "transformers>=4.41.0,<5.0", # avoid major bump
-  "torch>=2.4.0,<3.0",
-]
 test = []  # TODO - list
 
 [project.urls]


### PR DESCRIPTION
This was an oversight in #327 .

Not really a massive issue. Installing this optional extra just doesn't actually include anything.

PS:
I suppose we _could_ add the [PyPI release of embedding linker](http://pypi.org/project/medcat-embedding-linker) here. But I really wouldn't like the circular dependency that would create (and, in fact, I'm not even sure if it would work due to that).