### PR TITLE
bug(medcat): CU-869cunfx7 Fix supervised training order of operations issue

### DIFF
--- a/medcat-v2/medcat/pipeline/pipeline.py
+++ b/medcat-v2/medcat/pipeline/pipeline.py
@@ -345,6 +345,14 @@ class Pipeline:
         Returns:
             MutableEntity: The resulting entity.
         """
+        warnings.warn(
+            "The `medcat.pipeline.pipeline.Pipeline.entity_from_tokens` method is"
+            "depreacated is subject to removal in a future release. Please use "
+            "`medcat.pipeline.pipeline.Pipeline.entity_from_tokens_in_doc` "
+            "instead.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         return self._tokenizer.entity_from_tokens(tokens)
 
     def entity_from_tokens_in_doc(self, tokens: list[MutableToken],

--- a/medcat-v2/medcat/pipeline/pipeline.py
+++ b/medcat-v2/medcat/pipeline/pipeline.py
@@ -44,13 +44,6 @@ class DelegatingTokenizer(BaseTokenizer):
             doc, token_start_index, token_end_index, label)
 
     def entity_from_tokens(self, tokens: list[MutableToken]) -> MutableEntity:
-        warnings.warn(
-            "The `medcat.pipeline.pipeline.entity_from_tokens` method is"
-            "depreacated and subject to removal in a future release. Please "
-            "use `medcat.pipeline.pipeline.entity_from_tokens_in_doc` instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
         return self.tokenizer.entity_from_tokens(tokens)
 
     def entity_from_tokens_in_doc(

--- a/medcat-v2/medcat/tokenizing/regex_impl/tokenizer.py
+++ b/medcat-v2/medcat/tokenizing/regex_impl/tokenizer.py
@@ -343,14 +343,6 @@ class RegexTokenizer(BaseTokenizer):
         # return Entity(span)
 
     def entity_from_tokens(self, tokens: list[MutableToken]) -> MutableEntity:
-        warnings.warn(
-            "The `medcat.tokenizing.tokenizers.Tokenizer.entity_from_tokens` method is"
-            "depreacated and subject to removal in a future release. Please use "
-            "`medcat.tokenizing.tokenizers.Tokenizer.entity_from_tokens_in_doc` "
-            "instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
         if not tokens:
             raise ValueError("Need at least one token for an entity")
         doc = cast(Token, tokens[0])._doc

--- a/medcat-v2/medcat/tokenizing/regex_impl/tokenizer.py
+++ b/medcat-v2/medcat/tokenizing/regex_impl/tokenizer.py
@@ -2,7 +2,6 @@ import re
 from typing import cast, Optional, Iterator, overload, Union, Any, Type
 from collections import defaultdict
 from bisect import bisect_left, bisect_right
-import warnings
 
 from medcat.tokenizing.tokens import (
     BaseToken, BaseEntity, BaseDocument,

--- a/medcat-v2/medcat/tokenizing/spacy_impl/tokenizers.py
+++ b/medcat-v2/medcat/tokenizing/spacy_impl/tokenizers.py
@@ -3,7 +3,6 @@ import re
 import os
 import shutil
 import logging
-import warnings
 
 import spacy
 from spacy.tokens import Span

--- a/medcat-v2/medcat/tokenizing/spacy_impl/tokenizers.py
+++ b/medcat-v2/medcat/tokenizing/spacy_impl/tokenizers.py
@@ -78,14 +78,6 @@ class SpacyTokenizer(BaseTokenizer):
         return Entity(span)
 
     def entity_from_tokens(self, tokens: list[MutableToken]) -> MutableEntity:
-        warnings.warn(
-            "The `medcat.tokenizing.tokenizers.Tokenizer.entity_from_tokens` method is"
-            "depreacated and subject to removal in a future release. Please use "
-            "`medcat.tokenizing.tokenizers.Tokenizer.entity_from_tokens_in_doc` "
-            "instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
         if not tokens:
             raise ValueError("Need at least one token for an entity")
         spacy_tokens = cast(list[Token], tokens)

--- a/medcat-v2/medcat/tokenizing/tokenizers.py
+++ b/medcat-v2/medcat/tokenizing/tokenizers.py
@@ -34,7 +34,18 @@ class BaseTokenizer(Protocol):
         pass
 
     def entity_from_tokens(self, tokens: list[MutableToken]) -> MutableEntity:
-        """Deprecated: use entity_from_tokens_in_doc instead."""
+        """Get an entity from the list of tokens.
+
+        This will create a new instance instead of looking for existing entity.
+        This method should be used only if/when there was no existing entity
+        within the specified document for the given span of tokens.
+
+        Args:
+            tokens (list[MutableToken]): List of tokens.
+
+        Returns:
+            MutableEntity: The resulting entity.
+        """
         pass
 
     def entity_from_tokens_in_doc(self, tokens: list[MutableToken],

--- a/medcat-v2/medcat/trainer.py
+++ b/medcat-v2/medcat/trainer.py
@@ -405,12 +405,18 @@ class Trainer:
                     devalue_others)
 
     def _prepare_doc_with_anns(
-            self, doc: MutableDocument,
+            self, doc: MutableDocument, ann_doc: MedCATTrainerExportDocument,
             anns: list[MedCATTrainerExportAnnotation]) -> None:
         ents = []
         for ann in anns:
             tkns = doc.get_tokens(ann['start'], ann['end'])
-            ents.append(self._pipeline.entity_from_tokens_in_doc(tkns, doc))
+            try:
+                ents.append(self._pipeline.entity_from_tokens_in_doc(tkns, doc))
+            except ValueError as err:
+                self._warn_on_error(
+                    err, doc.base.text,
+                    (ann['cui'], ann['value'], ann['start'], ann['end']),
+                    (None, ann_doc['id'], ann_doc['name']))
         # set NER ents
         doc.ner_ents.clear()
         doc.ner_ents.extend(ents)
@@ -418,6 +424,34 @@ class Trainer:
         doc.linked_ents.clear()
         doc.linked_ents.extend(ents)
 
+    def _warn_on_error(self, ve: BaseException, cur_text: str,
+                       mut_context_start: tuple[str, str, int, int],
+                       mut_context_end: tuple[MutableEntity | None, str, str]):
+        start, end = mut_context_start[2:]
+        context_window = 20  # characters
+        splitter_left, splitter_right = "<", ">"
+        context_start = max(start - context_window, 0)
+        context_end = min(end + context_window, len(cur_text) - 1)
+        context = (cur_text[context_start: start] +
+                    splitter_left +
+                    cur_text[start: end] +
+                    splitter_right +
+                    cur_text[end: context_end])
+        if context_start > 0:
+            context = "[...]" + context
+        if context_end < len(cur_text) - 1:
+            context += "[...]"
+        msg_template = (
+            "Failed to identify '%s' (%s) ([%d:%d]) "
+            "in '%s' %s within document %s | %s, "
+            "skipping training for this example")
+        msg_context = (
+            *mut_context_start, context, *mut_context_end)
+        if self.strict_train:
+            raise ValueError(msg_template % msg_context) from ve
+        else:
+            logger.warning(msg_template, *msg_context, exc_info=ve)
+# 480+ project
     def _train_supervised_for_project2(self,
                                        docs: list[MedCATTrainerExportDocument],
                                        current_document: int,
@@ -433,7 +467,7 @@ class Trainer:
             with temp_changed_config(self.config.components.linking,
                                      'train', False):
                 mut_doc = self.caller(doc['text'])
-            self._prepare_doc_with_anns(mut_doc, doc['annotations'])
+            self._prepare_doc_with_anns(mut_doc, doc, doc['annotations'])
 
             # Compatibility with old output where annotations are a list
             for ann, mut_entity in zip(doc['annotations'], mut_doc.linked_ents):
@@ -461,31 +495,10 @@ class Trainer:
                         mut_entity=mut_entity, negative=deleted,
                         devalue_others=devalue_others)
                 except (ValueError, KeyError) as ve:
-                    context_window = 20  # characters
-                    splitter_left, splitter_right = "<", ">"
-                    cur_text = doc['text']
-                    context_start = max(start - context_window, 0)
-                    context_end = min(end + context_window, len(cur_text) - 1)
-                    context = (cur_text[context_start: start] +
-                               splitter_left +
-                               cur_text[start: end] +
-                               splitter_right +
-                               cur_text[end: context_end])
-                    if context_start > 0:
-                        context = "[...]" + context
-                    if context_end < len(cur_text) - 1:
-                        context += "[...]"
-                    msg_template = (
-                        "Failed to identify '%s' (%s) ([%d:%d]) "
-                        "in '%s' %s within document %s | %s, "
-                        "skipping training for this example")
-                    msg_context = (
-                        cui, ann['value'], ann['start'], ann['end'],
-                        context, mut_entity, doc['id'], doc['name'])
-                    if self.strict_train:
-                        raise ValueError(msg_template % msg_context) from ve
-                    else:
-                        logger.warning(msg_template, *msg_context, exc_info=ve)
+                    self._warn_on_error(
+                        ve, doc['text'],
+                        (cui, ann['value'], ann['start'], ann['end']),
+                        (mut_entity, doc['id'], doc['name']))
             if train_from_false_positives:
                 fps: list[MutableEntity] = get_false_positives(doc, mut_doc)
 

--- a/medcat-v2/tests/test_trainer.py
+++ b/medcat-v2/tests/test_trainer.py
@@ -252,6 +252,31 @@ class TrainerSupervisedTests(TrainerUnsupervisedTests):
                 doc, ent = args.kwargs['mut_doc'], args.kwargs['mut_entity']
                 self.assertIn(ent, doc.linked_ents)
 
+    def test_empty_token_annotation_is_skipped_when_not_strict(self):
+        self.trainer.strict_train = False
+        with unittest.mock.patch.object(
+                self.trainer._pipeline, "entity_from_tokens_in_doc",
+                side_effect=ValueError("No tokens found in span")), \
+                unittest.mock.patch.object(
+                FakeMutDoc, "get_tokens", return_value=[]), \
+                unittest.mock.patch.object(self.trainer, "add_and_train_concept"):
+            try:
+                self.train(self.TRAIN_DATA)
+            except ValueError as err:
+                raise err
+                # self.fail(f"Unexpected ValueError for empty-token annotation: {err}")
+
+    def test_empty_token_annotation_raises_when_strict(self):
+        self.trainer.strict_train = True
+        with unittest.mock.patch.object(
+                self.trainer._pipeline, "entity_from_tokens_in_doc",
+                side_effect=ValueError("No tokens found in span")), \
+                unittest.mock.patch.object(
+                FakeMutDoc, "get_tokens", return_value=[]), \
+                unittest.mock.patch.object(self.trainer, "add_and_train_concept"):
+            with self.assertRaises(ValueError):
+                self.train(self.TRAIN_DATA)
+
 
 class FromSratchBase(TrainedModelTests):
     RNG_SEED = 42

--- a/medcat-v2/tests/test_trainer.py
+++ b/medcat-v2/tests/test_trainer.py
@@ -263,8 +263,7 @@ class TrainerSupervisedTests(TrainerUnsupervisedTests):
             try:
                 self.train(self.TRAIN_DATA)
             except ValueError as err:
-                raise err
-                # self.fail(f"Unexpected ValueError for empty-token annotation: {err}")
+                self.fail(f"Unexpected ValueError for empty-token annotation: {err}")
 
     def test_empty_token_annotation_raises_when_strict(self):
         self.trainer.strict_train = True


### PR DESCRIPTION
The previous PR #374 made a change where the call to the `Pipeline.pipeline.entity_from_tokens` method (previously called inside the `Trainer.add_and_train_concept` method) outside the try/except block in the `for` loop in the `Trainer._train_supervised_for_project2` method. So while previously issues where no tokens were found for a specific span were logged as warnings (at least normally), the change meant that these were raised instead.

This could happen if an annotated dataset had an annotation mid-token. For example, if trying to get the entity for `rb` in `orbits` the process will fail because the entire word is one token and the subpart of it cannot be accurately represented by any tokens.

So what this PR does:
- Fixes some minor deprecation warning issues from #374
  - Deprecation warnings were added to various tokenizer `entity_from_tokens` methods
    - Even though these remain to be used if/when there is no pre-existing entity corresponding to the span
    - So therefore these were now removed
  - Deprecation warning was NOT added to the `Pipeline.entity_from_tokens` method
    - This is what was actually not supposed to be used directly
    - So this deprecation warning was added
- Fixed the change by catching the exception and logging a warning like before
  - This involved separating out the warning logic so it can be used in different places
  - Though an exception can still be raised if `Trainer.strict_train = True` is set
- Adds a few tests to verfiy behaviour
  - Make sure that the exception is normally (`Trainer.strict_train == False`) not raised
  - And make sure that the exception is raised when `Trainer.strict_train` is true
  

The idea of the PR is that the first workflow will fail (it adds the tests, but not the actual fix).
And the subsequent one will succeed.