### PR TITLE
feat(medcat): CU-869cw9zmj Improve inference speed

### DIFF
--- a/medcat-v2/medcat/components/linking/vector_context_model.py
+++ b/medcat-v2/medcat/components/linking/vector_context_model.py
@@ -148,7 +148,13 @@ class ContextModel(AbstractSerialisable):
         # excluding center (center is the same for all window sizes)
         prev_left_vecs: list[np.ndarray] = []
         prev_right_vecs: list[np.ndarray] = []
-        center_vecs: Optional[list[np.ndarray]] = None  # same for all windows
+
+        # Center is identical for all window sizes, only compute once
+        if not self.config.context_ignore_center_tokens:
+            center_vecs = list(
+                self._preprocess_center_tokens(cui, tokens_center))
+        else:
+            center_vecs = []
 
         for context_type, window_size in sorted_contexts:
             tokens_left, tokens_center, tokens_right = self.get_context_tokens(
@@ -173,14 +179,6 @@ class ContextModel(AbstractSerialisable):
             prev_right_vecs = prev_right_vecs + new_right_vecs
             prev_left = tokens_left
             prev_right = tokens_right
-
-            # Center is identical for all window sizes, only compute once
-            if center_vecs is None:
-                if not self.config.context_ignore_center_tokens:
-                    center_vecs = list(
-                        self._preprocess_center_tokens(cui, tokens_center))
-                else:
-                    center_vecs = []
 
             values = prev_left_vecs + center_vecs + prev_right_vecs
             if values:

--- a/medcat-v2/medcat/components/linking/vector_context_model.py
+++ b/medcat-v2/medcat/components/linking/vector_context_model.py
@@ -511,7 +511,7 @@ def update_context_vectors(to_update: dict[str, np.ndarray], cui: str,
                          "Is Negative: %s, LR: %.5f, b: %.3f", cui,
                          context_type, similarity, negative, lr, b)
             cv = to_update[context_type]
-            similarity_after = np.dot(unitvec(cv.copy()), unitvec(vector))
+            similarity_after = np.dot(unitvec(cv), unitvec(vector))
             logger.debug("Similarity before vs after: %.5f vs %.5f",
                          similarity, similarity_after)
         else:

--- a/medcat-v2/medcat/components/linking/vector_context_model.py
+++ b/medcat-v2/medcat/components/linking/vector_context_model.py
@@ -155,7 +155,7 @@ class ContextModel(AbstractSerialisable):
                 entity, doc, window_size, per_doc_valid_token_cache)
 
             # New outer tokens only — the inner ones were already processed
-            new_left = tokens_left[:len(tokens_left) - len(prev_left)]
+            new_left = tokens_left[len(prev_left):]
             new_right = tokens_right[len(prev_right):]
 
             # step_start for new left tokens: they are further from centre

--- a/medcat-v2/medcat/components/linking/vector_context_model.py
+++ b/medcat-v2/medcat/components/linking/vector_context_model.py
@@ -91,9 +91,10 @@ class ContextModel(AbstractSerialisable):
 
         return tokens_left, tokens_center, tokens_right
 
-    def _tokens2vecs(self, tokens: Sequence[Union[MutableToken, str]]
-                     ) -> Iterable[np.ndarray]:
-        for step, tkn in enumerate(tokens):
+    def _tokens2vecs(self, tokens: Sequence[Union[MutableToken, str]],
+                    step_start: int = 0
+                    ) -> Iterable[np.ndarray]:
+        for step, tkn in enumerate(tokens, start=step_start):
             lower = tkn.lower() if isinstance(tkn, str) else tkn.base.lower
             if lower not in self.vocab:
                 continue
@@ -137,26 +138,52 @@ class ContextModel(AbstractSerialisable):
         """
         vectors: dict[str, np.ndarray] = {}
 
-        context_vector_sizes = self.config.context_vector_sizes
-        for context_type, window_size in context_vector_sizes.items():
+        # Sort ascending so each iteration is a superset of the previous
+        sorted_contexts = sorted(
+            self.config.context_vector_sizes.items(), key=lambda x: x[1])
+
+        prev_left: list[MutableToken] = []
+        prev_right: list[MutableToken] = []
+        # Accumulated weighted vecs from previous (smaller) windows,
+        # excluding center (center is the same for all window sizes)
+        prev_left_vecs: list[np.ndarray] = []
+        prev_right_vecs: list[np.ndarray] = []
+        center_vecs: Optional[list[np.ndarray]] = None  # same for all windows
+
+        for context_type, window_size in sorted_contexts:
             tokens_left, tokens_center, tokens_right = self.get_context_tokens(
                 entity, doc, window_size, per_doc_valid_token_cache)
 
-            values: list[np.ndarray] = []
-            # Add left
-            values.extend(self._tokens2vecs(tokens_left))
+            # New outer tokens only — the inner ones were already processed
+            new_left = tokens_left[:len(tokens_left) - len(prev_left)]
+            new_right = tokens_right[len(prev_right):]
 
-            if not self.config.context_ignore_center_tokens:
-                # Add center
-                values.extend(
-                    self._preprocess_center_tokens(cui, tokens_center))
+            # step_start for new left tokens: they are further from centre
+            # so their step index is
+            # len(tokens_left) - len(new_left) ... len(tokens_left)-1
+            # i.e. the new tokens are the outermost, highest-step ones
+            new_left_vecs = list(self._tokens2vecs(
+                new_left, step_start=len(prev_left)))
+            new_right_vecs = list(self._tokens2vecs(
+                new_right, step_start=len(prev_right)))
 
-            # Add right
-            values.extend(self._tokens2vecs(tokens_right))
+            prev_left_vecs = new_left_vecs + prev_left_vecs
+            prev_right_vecs = prev_right_vecs + new_right_vecs
+            prev_left = tokens_left
+            prev_right = tokens_right
 
+            # Center is identical for all window sizes, only compute once
+            if center_vecs is None:
+                if not self.config.context_ignore_center_tokens:
+                    center_vecs = list(
+                        self._preprocess_center_tokens(cui, tokens_center))
+                else:
+                    center_vecs = []
+
+            values = prev_left_vecs + center_vecs + prev_right_vecs
             if values:
-                value = np.average(values, axis=0)
-                vectors[context_type] = value
+                vectors[context_type] = np.average(values, axis=0)
+
         return vectors
 
     def similarity(self, cui: str, entity: MutableEntity, doc: MutableDocument,

--- a/medcat-v2/medcat/components/linking/vector_context_model.py
+++ b/medcat-v2/medcat/components/linking/vector_context_model.py
@@ -155,6 +155,8 @@ class ContextModel(AbstractSerialisable):
                 entity, doc, window_size, per_doc_valid_token_cache)
 
             # New outer tokens only — the inner ones were already processed
+            # NOTE: left hand tokens are in order of closest first, which is why
+            #       we're slicing from the start of the list
             new_left = tokens_left[len(prev_left):]
             new_right = tokens_right[len(prev_right):]
 

--- a/medcat-v2/medcat/components/linking/vector_context_model.py
+++ b/medcat-v2/medcat/components/linking/vector_context_model.py
@@ -511,7 +511,7 @@ def update_context_vectors(to_update: dict[str, np.ndarray], cui: str,
                          "Is Negative: %s, LR: %.5f, b: %.3f", cui,
                          context_type, similarity, negative, lr, b)
             cv = to_update[context_type]
-            similarity_after = np.dot(unitvec(cv), unitvec(vector))
+            similarity_after = np.dot(unitvec(cv.copy()), unitvec(vector))
             logger.debug("Similarity before vs after: %.5f vs %.5f",
                          similarity, similarity_after)
         else:

--- a/medcat-v2/medcat/components/linking/vector_context_model.py
+++ b/medcat-v2/medcat/components/linking/vector_context_model.py
@@ -58,6 +58,7 @@ class ContextModel(AbstractSerialisable):
     def get_context_tokens(self, entity: MutableEntity, doc: MutableDocument,
                            size: int,
                            per_doc_valid_token_cache: 'PerDocumentTokenCache',
+                           fill_centre_tokens: bool = True,
                            ) -> tuple[list[MutableToken],
                                       list[MutableToken],
                                       list[MutableToken]]:
@@ -83,8 +84,11 @@ class ContextModel(AbstractSerialisable):
                        per_doc_valid_token_cache[tkn]]
         # Reverse because the first token should be the one closest to center
         tokens_left.reverse()
-        tokens_center: list[MutableToken] = list(
-            cast(Iterable[MutableToken], entity))
+        if fill_centre_tokens:
+            tokens_center: list[MutableToken] = list(
+                cast(Iterable[MutableToken], entity))
+        else:
+            tokens_center = []
         _right_tokens = doc[end_ind + 1:end_ind + 1 + size]
         tokens_right = [tkn for tkn in _right_tokens if
                         per_doc_valid_token_cache[tkn]]
@@ -151,14 +155,17 @@ class ContextModel(AbstractSerialisable):
 
         # Center is identical for all window sizes, only compute once
         if not self.config.context_ignore_center_tokens:
+            tokens_center =  list(
+                cast(Iterable[MutableToken], entity))
             center_vecs = list(
                 self._preprocess_center_tokens(cui, tokens_center))
         else:
             center_vecs = []
 
         for context_type, window_size in sorted_contexts:
-            tokens_left, tokens_center, tokens_right = self.get_context_tokens(
-                entity, doc, window_size, per_doc_valid_token_cache)
+            tokens_left, _, tokens_right = self.get_context_tokens(
+                entity, doc, window_size, per_doc_valid_token_cache,
+                fill_centre_tokens=False)
 
             # New outer tokens only — the inner ones were already processed
             # NOTE: left hand tokens are in order of closest first, which is why

--- a/medcat-v2/medcat/components/linking/vector_context_model.py
+++ b/medcat-v2/medcat/components/linking/vector_context_model.py
@@ -155,7 +155,7 @@ class ContextModel(AbstractSerialisable):
 
         # Center is identical for all window sizes, only compute once
         if not self.config.context_ignore_center_tokens:
-            tokens_center =  list(
+            tokens_center = list(
                 cast(Iterable[MutableToken], entity))
             center_vecs = list(
                 self._preprocess_center_tokens(cui, tokens_center))

--- a/medcat-v2/medcat/utils/matutils.py
+++ b/medcat-v2/medcat/utils/matutils.py
@@ -15,7 +15,8 @@ def unitvec(vec: np.ndarray) -> np.ndarray:
     Returns:
         np.ndarray: The new unit vector.
     """
-    return vec / np.linalg.norm(vec)
+    vec /= np.sqrt(vec @ vec)
+    return vec
 
 
 @overload

--- a/medcat-v2/medcat/utils/matutils.py
+++ b/medcat-v2/medcat/utils/matutils.py
@@ -15,8 +15,7 @@ def unitvec(vec: np.ndarray) -> np.ndarray:
     Returns:
         np.ndarray: The new unit vector.
     """
-    vec /= np.sqrt(vec @ vec)
-    return vec
+    return vec / np.linalg.norm(vec)
 
 
 @overload


### PR DESCRIPTION
This PR improves inference speed somewhat (around 10%) by:
- ~~Using a more efficient unitvec calculation~~
  - This gave a nice boost to speed (around 20% on this segment)
  - But it was doing the change in place so that polluted other bits which broke a bunch of stuff
  - However, this speedup came from a very small section of the overall time
  - So the overall speedup of this would have been closer to 1%
- Reusing smaller context vectors mutiple times
  - We've cont multiple context windows (small, medium, large, extra larget)
  - So far we've been recalculating the vectors for all of these for every context window
  - However, the smaller ones will always need to be a subset of the bigger ones
  - So this change will take advantage of that
