### PR TITLE
feat(medcat-den): Make credentials optional for remote dens

### DIFF
--- a/medcat-den/src/medcat_den/config.py
+++ b/medcat-den/src/medcat_den/config.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Optional
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -16,7 +16,7 @@ class LocalDenConfig(DenConfig):
 
 class RemoteDenConfig(DenConfig):
     host: str
-    credentials: dict
+    credentials: Optional[dict] = None
     allow_local_fine_tune: bool
     allow_push_fine_tuned: bool
 

--- a/medcat-den/src/medcat_den/resolver/resolver.py
+++ b/medcat-den/src/medcat_den/resolver/resolver.py
@@ -96,8 +96,6 @@ def _init_den_cnf(
         host = host or os.getenv(MEDCAT_DEN_REMOTE_HOST)
         if not host:
             raise ValueError("Need to specify a host for remote den")
-        if not credentials:
-            raise ValueError("Need to specify credentials for remote den")
         # NOTE: these will default to False when nothing is specified
         #       because "None" is not in ALLOW_OPTION_LOWERCASE
         allow_local_fine_tune = str(


### PR DESCRIPTION

## Current Behavior
- I have a medcattery instance with no authentication, this is the default when I start it up.
- I can't use medcat-den without passing an unused credentials block

EG I have to do this in the json:

```
        "medcattery_prod": {
            "type": "medcattery",
            "host": "https://medcattery.example.com",
            "credentials": {
                "unused: "unused"
            }
        }
```

## New behavior

I should now be able to skip that credentials block altogether
```
        "medcattery_prod": {
            "type": "medcattery",
            "host": "https://medcattery.example.com"
}

```

(Note I also need to change medcat-den-medcattery implementation)