### PR TITLE
Fix issue with PR paths for embedding linker workflow

### DIFF
--- a/.github/workflows/medcat-embedding-linker_ci.yml
+++ b/.github/workflows/medcat-embedding-linker_ci.yml
@@ -7,7 +7,7 @@ on:
       - 'medcat-embedding-linker/v*.*.*'  
   pull_request:
     paths:
-      - 'medcat-plugins/medcat-embedding-linker/**'
+      - 'medcat-plugins/embedding-linker/**'
       - '.github/workflows/medcat-embedding-linker**'
 
 permissions:

--- a/.github/workflows/medcat-embedding-linker_ci.yml
+++ b/.github/workflows/medcat-embedding-linker_ci.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - 'medcat-plugins/medcat-embedding-linker/**'
-      - '.github/workflows/medcat-embedding-linker**'
+      - '.github/workflows/embedding-linker**'
 
 permissions:
   id-token: write

--- a/.github/workflows/medcat-embedding-linker_ci.yml
+++ b/.github/workflows/medcat-embedding-linker_ci.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
     paths:
       - 'medcat-plugins/medcat-embedding-linker/**'
-      - '.github/workflows/embedding-linker**'
+      - '.github/workflows/medcat-embedding-linker**'
 
 permissions:
   id-token: write


### PR DESCRIPTION
The previous path was incorrect which meant the workflow didn't run at PR time.