### PR TITLE
fix(medcat-trainer): Fix Username emails missing when using oauth users

### DIFF
--- a/medcat-trainer/webapp/api/api/oidc_utils.py
+++ b/medcat-trainer/webapp/api/api/oidc_utils.py
@@ -3,11 +3,20 @@ import secrets
 
 def get_user_by_email(request, id_token):
     """
-    Resolve or create a Django user using the email claim from OIDC.
+    Resolve or create a Django user from OIDC claims.
+
+    Note: Some tokens (e.g. client-credentials / service-account tokens) may not
+    include an email claim. In that case, fall back to a stable identifier so
+    we don't violate DB NOT NULL constraints on the User model.
     """
     User = get_user_model()
-    email = id_token.get('email')
-    username = id_token.get('preferred_username')
+    username = (
+        id_token.get("preferred_username")
+        or id_token.get("sub")
+        or id_token.get("client_id")
+        or f"oidc-{secrets.token_urlsafe(8)}"
+    )
+    email = id_token.get("email") or username
     roles = id_token.get('roles', [])
     is_superuser = 'medcattrainer_superuser' in roles
     is_staff = 'medcattrainer_staff' in roles
@@ -16,6 +25,7 @@ def get_user_by_email(request, id_token):
         email=email,
         defaults={
             "username": username,
+            "email": email,
             "first_name": id_token.get("given_name", ""),
             "last_name": id_token.get("family_name", ""),
             "is_active": True,
@@ -24,6 +34,7 @@ def get_user_by_email(request, id_token):
     )
 
     user.username = username
+    user.email = email
     user.first_name = id_token.get("given_name", "")
     user.last_name = id_token.get("family_name", "")
     user.is_superuser = is_superuser


### PR DESCRIPTION

I see this when I try to get users with the `/api/users/` using the client secret user.

Reproduce with the medcat-trainer client

### Client side error 

```
Traceback (most recent call last):
  File "/home/ali/workspace/CogStack/cogstack-nlp/medcat-trainer/client/tests/integration/test_integration_mctclient.py", line 23, in test_get_users_contains_expected_users
    users = session.get_users()
            ^^^^^^^^^^^^^^^^^^^
  File "/home/ali/workspace/CogStack/cogstack-nlp/medcat-trainer/client/mctclient.py", line 554, in get_users
    raise MCTUtilsException(
mctclient.MCTUtilsException: Failed to get users from MedCATTrainer instance running at: https://medcat-trainer.app.cogstack.org 
 HTTP 500: <!DOCTYPE html>
<html lang="en">
<head>
  <meta http-equiv="content-type" content="text/html; charset=utf-8">
  <meta name="robots" content="NONE,NOARCHIVE">
  <title>IntegrityError
          at /api/users/</title>
  <style>
    html * { padding:0; margin:0; }
    body * { padding:10px 20px; }
    body * * { padding:0; }
    body { font-family: sans-serif; background-color:#fff; color:#000; }
    body > :where(header, main, footer) { border-bottom:1px solid #ddd; }
    h1 { font-weight:normal; }
```

### Server side error
```
[medcattrainer] psycopg.errors.NotNullViolation: null value in column "email" of relation "auth_user" violates not-null constraint
[medcattrainer] DETAIL:  Failing row contains (7, wwuZQcOkZ4XLLHqBs1I_3ELCRpYDAeC5C1uhpIJYM5E, null, f, service-account-cogstack-medcattrainer-backend, , , null, f, t, 2026-05-11 11:54:50.565221+00).
[medcattrainer]
[medcattrainer] The above exception was the direct cause of the following exception:
[medcattrainer]
[medcattrainer] Traceback (most recent call last):
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
[medcattrainer]     response = get_response(request)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
[medcattrainer]     response = wrapped_callback(request, *callback_args, **callback_kwargs)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
[medcattrainer]     return view_func(request, *args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/viewsets.py", line 125, in view
[medcattrainer]     return self.dispatch(request, *args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 515, in dispatch
[medcattrainer]     response = self.handle_exception(exc)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 475, in handle_exception
[medcattrainer]     self.raise_uncaught_exception(exc)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
[medcattrainer]     raise exc
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 503, in dispatch
[medcattrainer]     self.initial(request, *args, **kwargs)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 420, in initial
[medcattrainer]     self.perform_authentication(request)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 330, in perform_authentication
[medcattrainer]     request.user
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/request.py", line 232, in user
[medcattrainer]     self._authenticate()
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/request.py", line 385, in _authenticate
[medcattrainer]     user_auth_tuple = authenticator.authenticate(self)
[medcattrainer]                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/oidc_auth/authentication.py", line 78, in authenticate
[medcattrainer]     user = api_settings.OIDC_RESOLVE_USER_FUNCTION(request, userinfo)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/api/api/oidc_utils.py", line 15, in get_user_by_email
[medcattrainer]     user, created = User.objects.get_or_create(
[medcattrainer]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
[medcattrainer]     return getattr(self.get_queryset(), name)(*args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/query.py", line 955, in get_or_create
[medcattrainer]     return self.create(**params), True
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/query.py", line 665, in create
[medcattrainer]     obj.save(force_insert=True, using=self.db)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/contrib/auth/base_user.py", line 65, in save
[medcattrainer]     super().save(*args, **kwargs)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 902, in save
[medcattrainer]     self.save_base(
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 1008, in save_base
[medcattrainer]     updated = self._save_table(
[medcattrainer]               ^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 1169, in _save_table
[medcattrainer]     results = self._do_insert(
[medcattrainer]               ^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 1210, in _do_insert
[medcattrainer]     return manager._insert(
[medcattrainer]            ^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
[medcattrainer]     return getattr(self.get_queryset(), name)(*args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/query.py", line 1873, in _insert
[medcattrainer]     return query.get_compiler(using=using).execute_sql(returning_fields)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/sql/compiler.py", line 1882, in execute_sql
[medcattrainer]     cursor.execute(sql, params)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 122, in execute
[medcattrainer]     return super().execute(sql, params)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 79, in execute
[medcattrainer]     return self._execute_with_wrappers(
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers
[medcattrainer]     return executor(sql, params, many, context)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 100, in _execute
[medcattrainer]     with self.db.wrap_database_errors:
[medcattrainer]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/utils.py", line 91, in __exit__
[medcattrainer]     raise dj_exc_value.with_traceback(traceback) from exc_value
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute
[medcattrainer]     return self.cursor.execute(sql, params)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/psycopg/cursor.py", line 117, in execute
[medcattrainer]     raise ex.with_traceback(None)
[medcattrainer] django.db.utils.IntegrityError: null value in column "email" of relation "auth_user" violates not-null constraint
```