### PR TITLE
fix(medcattrainer) - solve `irrelevant` annotations document submit error

### DIFF
--- a/medcat-trainer/webapp/api/api/utils.py
+++ b/medcat-trainer/webapp/api/api/utils.py
@@ -412,10 +412,9 @@ def train_medcat(cat, project, document):
     irrelevant_anns = AnnotatedEntity.objects.filter(project=project, document=document, irrelevant=True)
     for ann in irrelevant_anns:
         cui = ann.entity.label
-        if 'cuis_exclude' not in cat.config.components.linking.filters:
-            cat.config.components.linking.filters['cuis_exclude'] = set()
-        cat.config.components.linking.filters.get('cuis_exclude').update([cui])
-
+        if cat.config.components.linking.filters.cuis_exclude is None:
+            cat.config.components.linking.filters.cuis_exclude = set()
+        cat.config.components.linking.filters.cuis_exclude.add(cui)
 
 @background(schedule=1, queue='doc_prep')
 def prep_docs(project_id: List[int], doc_ids: List[int], user_id: int):


### PR DESCRIPTION
In medcattrainer, if document annotations are marked as irrelevant, submitting a document throws a 500 error because MedCAT v2 uses a typed LinkingFilters object, not a dict.

```
TypeError: 'LinkingFilters' object does not support item assignment
cat.config.components.linking.filters['cuis_exclude'] = set()
```

Patch submitted as discussed on https://discourse.cogstack.org/t/medcat-trainer-issues-cant-submit-annotations-as-irrelevant/381