### PR TITLE
tests(medcat): CU-869d8wft4 Add tests to name count during supervised training

### DIFF
--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -635,6 +635,7 @@ class CATSupTrainingTests(CATUnsupTrainingTests):
             with self.subTest(f"Ann: {ann} vs Ent: {ent}"):
                 self.assertEqual(ann['start'], ent.base.start_char_index)
                 self.assertEqual(ann['end'], ent.base.end_char_index)
+
     def test_training_has_name_counts(self):
         self.assertTrue(self.cat.cdb.get_cui2count_train())
 

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -635,6 +635,13 @@ class CATSupTrainingTests(CATUnsupTrainingTests):
             with self.subTest(f"Ann: {ann} vs Ent: {ent}"):
                 self.assertEqual(ann['start'], ent.base.start_char_index)
                 self.assertEqual(ann['end'], ent.base.end_char_index)
+    def test_training_has_name_counts(self):
+        self.assertTrue(self.cat.cdb.get_cui2count_train())
+
+    def test_training_has_same_cui_and_name_counts(self):
+        cc = sum(self.cat.cdb.get_cui2count_train().values())
+        cn = sum(self.cat.cdb.get_name2count_train().values())
+        self.assertEqual(cc, cn)
 
 
 class CATWithDictNERSupTrainingTests(CATSupTrainingTests):


### PR DESCRIPTION
This seems to have not been working in MedCAT==2.5.3, see [this discourse thread](https://discourse.cogstack.org/t/new-synonyms-and-train-count-not-updating-general-query/384).

However, at a closer look it turned out this was in latest state of the codebase.
At a closer look it looks like this was fixed by #374 and released in v2.7.0 (April 1st).

I verified by checking that the issue does exist in v2.6.0 but does not in v2.7.0.

Nevertheless, I felt like adding tests for this would be appropriate.