### PR TITLE
feat(medcat): CU-869d9n2rg Avoid running pipe twice for supervised training

### DIFF
--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -660,8 +660,10 @@ class CAT(AbstractSerialisable):
     def trainer(self):
         """The trainer object."""
         if not self._trainer:
+            tknzer = self._pipeline.tokenizer_with_tag.__call__
+            pipe = self._pipeline.get_doc
             self._trainer = Trainer(
-                self.cdb, self._pipeline.tokenizer_with_tag.__call__, self._pipeline)
+                self.cdb, tknzer, pipe, self._pipeline)
         return self._trainer
 
     def save_model_card(self, model_card_path: str) -> None:

--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -660,10 +660,7 @@ class CAT(AbstractSerialisable):
     def trainer(self):
         """The trainer object."""
         if not self._trainer:
-            tknzer = self._pipeline.tokenizer_with_tag.__call__
-            pipe = self._pipeline.get_doc
-            self._trainer = Trainer(
-                self.cdb, tknzer, pipe, self._pipeline)
+            self._trainer = Trainer(self.cdb, self._pipeline)
         return self._trainer
 
     def save_model_card(self, model_card_path: str) -> None:

--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -661,7 +661,7 @@ class CAT(AbstractSerialisable):
         """The trainer object."""
         if not self._trainer:
             self._trainer = Trainer(
-                self.cdb, self._pipe.line.tokenizer_with_tag.__call__, self._pipeline)
+                self.cdb, self._pipeline.tokenizer_with_tag.__call__, self._pipeline)
         return self._trainer
 
     def save_model_card(self, model_card_path: str) -> None:

--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -660,7 +660,8 @@ class CAT(AbstractSerialisable):
     def trainer(self):
         """The trainer object."""
         if not self._trainer:
-            self._trainer = Trainer(self.cdb, self.__call__, self._pipeline)
+            self._trainer = Trainer(
+                self.cdb, self._pipe.line.tokenizer_with_tag.__call__, self._pipeline)
         return self._trainer
 
     def save_model_card(self, model_card_path: str) -> None:

--- a/medcat-v2/medcat/trainer.py
+++ b/medcat-v2/medcat/trainer.py
@@ -28,11 +28,14 @@ logger = logging.getLogger(__name__)
 class Trainer:
     strict_train: bool = False
 
-    def __init__(self, cdb: CDB, caller: Callable[[str], MutableDocument],
+    def __init__(self, cdb: CDB,
+                 tokenizer: Callable[[str], MutableDocument],
+                 pipe: Callable[[str], MutableDocument],
                  pipeline: Pipeline):
         self.cdb = cdb
         self.config = cdb.config
-        self.caller = caller
+        self.tokenizer = tokenizer
+        self.pipe = pipe
         self._pipeline = pipeline
 
     def train_unsupervised(self,
@@ -92,7 +95,7 @@ class Trainer:
 
                 # inference run for the document
                 try:
-                    doc = self.caller(line)
+                    doc = self.pipe(line)
                 except Exception as e:
                     logger.warning("LINE: '%s...' \t WAS SKIPPED", line[0:100])
                     logger.warning("BECAUSE OF:", exc_info=e)
@@ -471,7 +474,8 @@ class Trainer:
             doc = docs[idx_doc]
             with temp_changed_config(self.config.components.linking,
                                      'train', False):
-                mut_doc = self.caller(doc['text'])
+                # NOTE: only need tokenization here
+                mut_doc = self.tokenizer(doc['text'])
             self._prepare_doc_with_anns(mut_doc, doc, doc['annotations'])
 
             # Compatibility with old output where annotations are a list

--- a/medcat-v2/medcat/trainer.py
+++ b/medcat-v2/medcat/trainer.py
@@ -419,7 +419,12 @@ class Trainer:
         for ann in anns:
             tkns = doc.get_tokens(ann['start'], ann['end'])
             try:
-                ents.append(self._pipeline.entity_from_tokens_in_doc(tkns, doc))
+                ent = self._pipeline.entity_from_tokens_in_doc(tkns, doc)
+                # avoid setting CUI so as to not show our hand
+                raw_name = ann['value'].lower().replace(
+                    " ", self.cdb.config.general.separator)
+                ent.detected_name = raw_name
+                ents.append(ent)
             except ValueError as err:
                 self._warn_on_error(
                     err, doc.base.text,

--- a/medcat-v2/medcat/trainer.py
+++ b/medcat-v2/medcat/trainer.py
@@ -420,9 +420,16 @@ class Trainer:
             tkns = doc.get_tokens(ann['start'], ann['end'])
             try:
                 ent = self._pipeline.entity_from_tokens_in_doc(tkns, doc)
-                raw_name = ann['value'].lower().replace(
-                    " ", self.cdb.config.general.separator)
-                ent.detected_name = raw_name
+                pn_dict = prepare_name(ann['value'], self._pipeline.tokenizer, {},
+                                 self._pn_configs)
+                processed_names = list(pn_dict.keys())
+                if len(processed_names) > 1:
+                    logger.info("Got multiple processed names for %s: %s",
+                                ann['value'], processed_names)
+                elif not processed_names:
+                    # NOTE: shouldn't really happen
+                    raise ValueError(f"Could not process {ann['value']} into names")
+                ent.detected_name = processed_names[0]
                 ent.cui = ann['cui']
                 ents.append(ent)
             except ValueError as err:

--- a/medcat-v2/medcat/trainer.py
+++ b/medcat-v2/medcat/trainer.py
@@ -655,6 +655,7 @@ class Trainer:
                 mut_entity = self._pipeline.entity_from_tokens(mut_entity)
             component.train(cui=cui, entity=mut_entity, doc=mut_doc,
                             negative=negative, names=names)
+            trained_comps += 1
 
             if not negative and devalue_others:
                 # Find all cuis

--- a/medcat-v2/medcat/trainer.py
+++ b/medcat-v2/medcat/trainer.py
@@ -1,4 +1,4 @@
-from typing import Iterable, Callable, Optional, Union, cast
+from typing import Iterable, Optional, Union, cast
 import logging
 import tempfile
 from itertools import chain, repeat, islice

--- a/medcat-v2/medcat/trainer.py
+++ b/medcat-v2/medcat/trainer.py
@@ -29,13 +29,9 @@ class Trainer:
     strict_train: bool = False
 
     def __init__(self, cdb: CDB,
-                 tokenizer: Callable[[str], MutableDocument],
-                 pipe: Callable[[str], MutableDocument],
                  pipeline: Pipeline):
         self.cdb = cdb
         self.config = cdb.config
-        self.tokenizer = tokenizer
-        self.pipe = pipe
         self._pipeline = pipeline
 
     def train_unsupervised(self,
@@ -95,7 +91,7 @@ class Trainer:
 
                 # inference run for the document
                 try:
-                    doc = self.pipe(line)
+                    doc = self._pipeline.get_doc(line)
                 except Exception as e:
                     logger.warning("LINE: '%s...' \t WAS SKIPPED", line[0:100])
                     logger.warning("BECAUSE OF:", exc_info=e)
@@ -487,7 +483,7 @@ class Trainer:
             with temp_changed_config(self.config.components.linking,
                                      'train', False):
                 # NOTE: only need tokenization here
-                mut_doc = self.tokenizer(doc['text'])
+                mut_doc = self._pipeline.tokenizer_with_tag(doc['text'])
             self._prepare_doc_with_anns(mut_doc, doc, doc['annotations'])
 
             # Compatibility with old output where annotations are a list

--- a/medcat-v2/medcat/trainer.py
+++ b/medcat-v2/medcat/trainer.py
@@ -420,10 +420,10 @@ class Trainer:
             tkns = doc.get_tokens(ann['start'], ann['end'])
             try:
                 ent = self._pipeline.entity_from_tokens_in_doc(tkns, doc)
-                # avoid setting CUI so as to not show our hand
                 raw_name = ann['value'].lower().replace(
                     " ", self.cdb.config.general.separator)
                 ent.detected_name = raw_name
+                ent.cui = ann['cui']
                 ents.append(ent)
             except ValueError as err:
                 self._warn_on_error(

--- a/medcat-v2/tests/test_trainer.py
+++ b/medcat-v2/tests/test_trainer.py
@@ -138,7 +138,7 @@ class TrainerTestsBase(unittest.TestCase):
         cls.cdb = FakeCDB(cls.cnf)
         cls.vocab = Vocab()
         cls.trainer = Trainer(cls.cdb,
-                              cls.caller, FakePipeline())
+                              cls.caller, cls.caller, FakePipeline())
 
     def setUp(self):
         self.cnf = Config()
@@ -204,6 +204,7 @@ class TrainerUnsupervisedTests(TrainerTestsBase):
         trainer = Trainer(
             self.cdb,
             self.caller,
+            self.caller,
             FakePipelineWithComponents([ner_component]),
         )
         trainer.config = self.cnf
@@ -219,6 +220,7 @@ class TrainerUnsupervisedTests(TrainerTestsBase):
         ner_component = FakeTrainableNERComponent()
         trainer = Trainer(
             self.cdb,
+            self.caller,
             self.caller,
             FakePipelineWithComponents([FakeComponent(), ner_component, object()]),
         )

--- a/medcat-v2/tests/test_trainer.py
+++ b/medcat-v2/tests/test_trainer.py
@@ -1,5 +1,6 @@
 import os
 import json
+from typing import Callable
 
 from medcat.tokenizing.tokens import MutableDocument
 from medcat.trainer import Trainer
@@ -100,6 +101,12 @@ class FakeTrainableNERComponent:
 
 class FakePipeline:
 
+    def __init__(self, caller: Callable[[str], MutableDocument] = None) -> None:
+        self._caller = caller or FakeMutDoc
+
+    def get_doc(self, text: str) -> FakeMutDoc:
+        return self._caller(text)
+
     def tokenizer(self, text: str) -> FakeMutDoc:
         return FakeMutDoc(text)
 
@@ -118,7 +125,8 @@ class FakePipeline:
 
 class FakePipelineWithComponents(FakePipeline):
 
-    def __init__(self, components: list):
+    def __init__(self, components: list, caller: Callable[[str], MutableDocument] = None):
+        super().__init__(caller)
         self._components = components
 
     def iter_all_components(self):
@@ -137,8 +145,7 @@ class TrainerTestsBase(unittest.TestCase):
         cls.cnf = Config()
         cls.cdb = FakeCDB(cls.cnf)
         cls.vocab = Vocab()
-        cls.trainer = Trainer(cls.cdb,
-                              cls.caller, cls.caller, FakePipeline())
+        cls.trainer = Trainer(cls.cdb, FakePipeline(cls.caller))
 
     def setUp(self):
         self.cnf = Config()
@@ -203,9 +210,7 @@ class TrainerUnsupervisedTests(TrainerTestsBase):
         ner_component = FakeTrainableNERComponent()
         trainer = Trainer(
             self.cdb,
-            self.caller,
-            self.caller,
-            FakePipelineWithComponents([ner_component]),
+            FakePipelineWithComponents([ner_component], self.caller),
         )
         trainer.config = self.cnf
 
@@ -220,9 +225,7 @@ class TrainerUnsupervisedTests(TrainerTestsBase):
         ner_component = FakeTrainableNERComponent()
         trainer = Trainer(
             self.cdb,
-            self.caller,
-            self.caller,
-            FakePipelineWithComponents([FakeComponent(), ner_component, object()]),
+            FakePipelineWithComponents([FakeComponent(), ner_component, object()], self.caller),
         )
         trainer.config = self.cnf
 

--- a/medcat-v2/tests/utils/test_training_utils.py
+++ b/medcat-v2/tests/utils/test_training_utils.py
@@ -231,7 +231,7 @@ class TrainingUtilsTests(unittest.TestCase):
         ner = _TrainableNER()
         linker = _TrainablePassThroughLinker()
         cat = _FakeCat(self.DATASET, [ner, linker])
-        trainer = Trainer(cat.cdb, cat.__call__, cat.pipe)
+        trainer = Trainer(cat.cdb, cat.pipe)
 
         with dataset_aware_component(cat, CoreComponentType.ner, self.DATASET):
             trainer.train_unsupervised(["abc def"], nepochs=1)
@@ -243,7 +243,7 @@ class TrainingUtilsTests(unittest.TestCase):
         ner = _TrainableNER()
         linker = _TrainablePassThroughLinker()
         cat = _FakeCat(self.DATASET, [ner, linker])
-        trainer = Trainer(cat.cdb, cat.__call__, cat.pipe)
+        trainer = Trainer(cat.cdb, cat.pipe)
 
         with dataset_aware_component(cat, CoreComponentType.linking, self.DATASET):
             trainer.train_unsupervised(["abc def"], nepochs=1)
@@ -255,7 +255,7 @@ class TrainingUtilsTests(unittest.TestCase):
         ner = _TrainableNER()
         linker = _TrainablePassThroughLinker()
         cat = _FakeCat(self.DATASET, [ner, linker])
-        trainer = Trainer(cat.cdb, cat.__call__, cat.pipe)
+        trainer = Trainer(cat.cdb, cat.pipe)
 
         with unittest.mock.patch("medcat.trainer.prepare_name", return_value={"abc": {}}):
             with dataset_aware_component(cat, CoreComponentType.ner, self.DATASET):
@@ -268,7 +268,7 @@ class TrainingUtilsTests(unittest.TestCase):
         ner = _TrainableNER()
         linker = _TrainablePassThroughLinker()
         cat = _FakeCat(self.DATASET, [ner, linker])
-        trainer = Trainer(cat.cdb, cat.__call__, cat.pipe)
+        trainer = Trainer(cat.cdb, cat.pipe)
 
         with unittest.mock.patch("medcat.trainer.prepare_name", return_value={"abc": {}}):
             with dataset_aware_component(cat, CoreComponentType.linking, self.DATASET):

--- a/medcat-v2/tests/utils/test_training_utils.py
+++ b/medcat-v2/tests/utils/test_training_utils.py
@@ -4,6 +4,7 @@ import unittest.mock
 from medcat.config import Config
 from medcat.components.types import CoreComponentType, AbstractEntityProvidingComponent
 from medcat.stats.stats import get_stats
+from medcat.tokenizing.tokens import MutableDocument
 from medcat.trainer import Trainer
 from medcat.utils.training_utils import dataset_aware_component
 
@@ -58,6 +59,9 @@ class _FakeTokenizer:
         text = doc.text[start:end]
         cui = doc.cui_by_start.get(start, "C_WRONG")
         return _FakeEntity(start, end, text, cui)
+
+    def __call__(self, text: str) -> _FakeDoc:
+        return _FakeDoc(text, {})
 
 
 class _EmptyNER(AbstractEntityProvidingComponent):
@@ -139,6 +143,9 @@ class _FakePipeline:
             if comp.get_type() == comp_type:
                 return comp
         raise KeyError(comp_type)
+
+    def get_doc(self, text: str) -> MutableDocument:
+        return self(self.tokenizer(text))
 
     def iter_all_components(self):
         return self._components


### PR DESCRIPTION
This PR separates the callers used for supervised and self-supervised training.

The self-supervised training will run the entire pipe.
And the supervised training only runs the tokenizer.

Along the way also fixed up a few minor things
- The trainable component counting based warning (i.e when nothing to train)
- The entities sent to be trained supervised now have a detected name
  - Without it the name counts wouldn't be updated

<details>
<summary>Original(ish) description</summary>
If all goes well this just works out of the box.

EDIT:
Looks like it's not working since the linker unsupervised training needs the NER step to have run because otherwise it doesn't know what entities to train on. Need to figure out a solution for that.
</summary>