### PR TITLE
fix(medcat): CU-869ddh1jv: Fix lock file issue.

### DIFF
--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -69,6 +69,9 @@ dependencies = [ # Optional
   "pyyaml",
   "requests",
   # TODO - others
+  # NOTE: transitive dependency that breaks other deps
+  #       e.g `spacy`'s dependency `click` isn't installed
+  "typer!=0.26.2",
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -71,7 +71,7 @@ dependencies = [ # Optional
   # TODO - others
   # NOTE: transitive dependency that breaks other deps
   #       e.g `spacy`'s dependency `click` isn't installed
-  "typer!=0.26.2",
+  "typer!=0.26.0,!=0.26.1,!=0.26.2",
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/medcat-v2/uv.lock
+++ b/medcat-v2/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13'",
     "python_full_version == '3.12.*'",
@@ -873,6 +873,7 @@ deid = [
 ]
 dev = [
     { name = "mypy" },
+    { name = "pooch" },
     { name = "ruff" },
     { name = "types-pyyaml" },
     { name = "types-setuptools" },
@@ -898,6 +899,11 @@ spacy = [
     { name = "spacy" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pooch" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "datasets", marker = "extra == 'deid'", specifier = ">=2.2.2,<3.0.0" },
@@ -908,6 +914,7 @@ requires-dist = [
     { name = "packaging" },
     { name = "pandas", specifier = ">=2.2,<3.0" },
     { name = "peft", marker = "extra == 'meta-cat'", specifier = ">0.8.2,<1.0" },
+    { name = "pooch", marker = "extra == 'dev'" },
     { name = "pyahocorasick", marker = "extra == 'dict-ner'", specifier = ">=2.1.0,<3.0" },
     { name = "pydantic", specifier = ">2.0" },
     { name = "pyyaml" },
@@ -935,6 +942,9 @@ requires-dist = [
     { name = "xxhash", specifier = ">=3.5.0,<4.0" },
 ]
 provides-extras = ["dev", "spacy", "meta-cat", "dict-ner", "deid", "rel-cat", "test"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pooch", specifier = ">=1.9.0" }]
 
 [[package]]
 name = "mpmath"
@@ -1551,6 +1561,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/70/b8/2e79377efaa1e5f0d70a497db7914ffd355846e760ffa2f7883ab0f600fb/peft-0.17.1.tar.gz", hash = "sha256:e6002b42517976c290b3b8bbb9829a33dd5d470676b2dec7cb4df8501b77eb9f", size = 568192, upload-time = "2025-08-21T09:25:22.703Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/fe/a2da1627aa9cb6310b6034598363bd26ac301c4a99d21f415b1b2855891e/peft-0.17.1-py3-none-any.whl", hash = "sha256:3d129d64def3d74779c32a080d2567e5f7b674e77d546e3585138216d903f99e", size = 504896, upload-time = "2025-08-21T09:25:18.974Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
+]
+
+[[package]]
+name = "pooch"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/43/85ef45e8b36c6a48546af7b266592dc32d7f67837a6514d111bced6d7d75/pooch-1.9.0.tar.gz", hash = "sha256:de46729579b9857ffd3e741987a2f6d5e0e03219892c167c6578c0091fb511ed", size = 61788, upload-time = "2026-01-30T19:15:09.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2d/d4bf65e47cea8ff2c794a600c4fd1273a7902f268757c531e0ee9f18aa58/pooch-1.9.0-py3-none-any.whl", hash = "sha256:f265597baa9f760d25ceb29d0beb8186c243d6607b0f60b83ecf14078dbc703b", size = 67175, upload-time = "2026-01-30T19:15:08.36Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Issue was introduced in #503. Looks like because I didn't update uv.lock the entire dependency resolution was redone and broke. This PR should - hopefully - fix it.

The underlying issue was that `click` wasn't installed. Looks like the latest `typer` (0.26.0+) removed it from the requirements. But the exception would suggest that `click` is also a requirement of `spacy`. But they don't seem to define it as an explicit dependency. I guess they've relied it being available transitively through `typer`.

So this PR will disallow `typer~=0.26.[012]` (at least for now), which seems to fix the issue.

<details>
<summary>Exception</summary>

```
File /opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/medcat/utils/registry.py:96, in Registry._ensure_lazy_default(self, component_name)
     92 module_name, class_name = self._lazy_components.pop(component_name)
     93 logger.debug("Registering default %s '%s': '%s.%s'",
     94              self._type.__name__, component_name, module_name,
     95              class_name)
---> 96 module_in = importlib.import_module(module_name)
     97 if "." in class_name:
     98     cls_name, method_name = class_name.split(".")

File /opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/importlib/__init__.py:126, in import_module(name, package)
    124             break
    125         level += 1
--> 126 return _bootstrap._gcd_import(name[level:],package,level)

File <frozen importlib._bootstrap>:1204, in _gcd_import(name, package, level)

File <frozen importlib._bootstrap>:1176, in _find_and_load(name, import_)

File <frozen importlib._bootstrap>:1150, in _find_and_load_unlocked(name, import_)

File <frozen importlib._bootstrap>:705, in _load_unlocked(spec)

File <frozen importlib._bootstrap_external>:940, in _LoaderBasics.exec_module(self, module)

File <frozen importlib._bootstrap>:241, in _call_with_frames_removed(f, *args, **kwds)

File /opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/medcat/tokenizing/spacy_impl/tokenizers.py:7
      4 import shutil
      5 import logging
----> 7 import spacy
      8 from spacy.tokens import Span
      9 from spacy.tokenizer import Tokenizer  # type: ignore

File /opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/spacy/__init__.py:18
     13 from . import (
     14     pipeline,  # noqa: F401
     15     util,
     16 )
     17 from .about import __version__  # noqa: F401
---> 18 from .cli.info import info  # noqa: F401
     19 from .errors import Errors
     20 from .glossary import explain  # noqa: F401

File /opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/spacy/cli/__init__.py:4
      1 from wasabi import msg
      3 # Needed for testing
----> 4 from . import download as download_module  # noqa: F401
      5 from ._util import app, setup_cli  # noqa: F401
      6 from .apply import apply  # noqa: F401

File /opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/spacy/cli/download.py:21
     12 from ..errors import OLD_MODEL_SHORTCUTS
     13 from ..util import (
     14     get_minor_version,
     15     is_in_interactive,
   (...)     19     run_command,
     20 )
---> 21 from ._util import SDIST_SUFFIX, WHEEL_SUFFIX, Arg, Opt, app
     24 @app.command(
     25     "download",
     26     context_settings={"allow_extra_args": True, "ignore_unknown_options": True},
   (...)     42     # fmt: on
     43 ):
     44     """
     45     Download compatible trained pipeline from the default download path using
     46     pip. If --direct flag is set, the command expects the full package name with
   (...)     52     AVAILABLE PACKAGES: https://spacy.io/models
     53     """

File /opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/spacy/cli/_util.py:18
     16 import srsly
     17 import typer
---> 18 from click import NoSuchOption
     19 from click.shell_completion import split_arg_string
     20 from thinc.api import ConfigValidationError, require_gpu

ModuleNotFoundError: No module named 'click'
```
</details>

EDIT: Further investigations suggest that this is indeed an issue with `spacy`. It's relied on `click` as a transitive dependency through `typer`. So now the install is failing. I've opened an issue on their side as well:
https://github.com/explosion/spaCy/issues/13971