### PR TITLE
build(medcat-den and embedding-linker): CU-869ddh1jv Fix downstream installs

### DIFF
--- a/medcat-den/pyproject.toml
+++ b/medcat-den/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
     "platformdirs>=4.4.0,<5.0",
     # for local cache of remote data (optional)
     "diskcache>=5.6.3,<6.0",
+    # NOTE: transitive dependency that breaks other deps
+    #       e.g `spacy`'s dependency `click` isn't installed
+    "typer!=0.26.0,!=0.26.1,!=0.26.2",
 ]
 
 [project.optional-dependencies]

--- a/medcat-plugins/embedding-linker/pyproject.toml
+++ b/medcat-plugins/embedding-linker/pyproject.toml
@@ -59,6 +59,9 @@ dependencies = [
   "transformers>=4.41.0,<5.0", # avoid major bump
   "torch>=2.4.0,<3.0",
   "tqdm",
+  # NOTE: transitive dependency that breaks other deps
+  #       e.g `spacy`'s dependency `click` isn't installed
+  "typer!=0.26.0,!=0.26.1,!=0.26.2",
 ]
 
 # List additional groups of dependencies here (e.g. development


### PR DESCRIPTION
This PR fixes downstream installs related to #505 and #503.

That's because these depend on a release version of `medcat` that hadn't specified the incompatible `typer` versions.