### PR TITLE
fix(medcat-embedding-linker): Fix issue causing workflows to fail

### DIFF
--- a/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
+++ b/medcat-plugins/embedding-linker/src/medcat_embedding_linker/trainable_embedding_linker.py
@@ -387,6 +387,17 @@ class Linker(StaticEmbeddingLinker, AbstractManualSerialisable):
             self._cui_context_matrix = None
             self.number_of_batches = 0
 
+    def train_unsupervised(self, doc: MutableDocument) -> None:
+        """Train unsupervised based on the given document.
+
+        If this component doesn't support unsupervised training,
+        this method can be a no-op.
+
+        Args:
+            doc (MutableDocument): The document to train on.
+        """
+        pass
+
     @classmethod
     def create_new_component(
         cls,


### PR DESCRIPTION
The tests require the trainable linker to follow the `TrainableComponent` protocol. But as of 2.8.0 the current implementation doesn't (since it doesn't declare the `train_unsupervised` method).

This PR fixes that.