### PR TITLE
build(medcat-den and medcat-embedding-linker): Make CI run against core lib state

### DIFF
--- a/.github/workflows/medcat-den_main.yml
+++ b/.github/workflows/medcat-den_main.yml
@@ -34,6 +34,7 @@ jobs:
           uv sync --all-extras --dev
           uv run python -m ensurepip
           uv run python -m pip install --upgrade pip
+          uv run python -m pip install "../medcat-v2[spacy,deid,meta-cat,rel-cat]"
       - name: Check types
         run: |
           uv run python -m mypy --follow-imports=normal src/medcat_den

--- a/.github/workflows/medcat-embedding-linker_ci.yml
+++ b/.github/workflows/medcat-embedding-linker_ci.yml
@@ -36,6 +36,7 @@ jobs:
           uv sync --all-extras --dev
           uv run python -m ensurepip
           uv run python -m pip install --upgrade pip
+          uv run python -m pip install "../medcat-v2[spacy]"
       - name: Check types
         run: |
           uv run python -m mypy --follow-imports=normal src/medcat_embedding_linker

--- a/.github/workflows/medcat-embedding-linker_ci.yml
+++ b/.github/workflows/medcat-embedding-linker_ci.yml
@@ -36,7 +36,7 @@ jobs:
           uv sync --all-extras --dev
           uv run python -m ensurepip
           uv run python -m pip install --upgrade pip
-          uv run python -m pip install "../medcat-v2[spacy]"
+          uv run python -m pip install "../../medcat-v2[spacy]"
       - name: Check types
         run: |
           uv run python -m mypy --follow-imports=normal src/medcat_embedding_linker


### PR DESCRIPTION
This PR has the workflows install medcat from current source state when testing these two.

This allows us to catch issues that I'm currently fixing in #515 and #516 at the time these changes are introduced not after they've been merged in and published.

EDIT:
This needs #515 and #516 to be merged in before workflow can pass.