### PR TITLE
build(medcat and medcat-den and medcat-embedding-linker): Fix spacy-click issue

### DIFF
--- a/medcat-den/pyproject.toml
+++ b/medcat-den/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "diskcache>=5.6.3,<6.0",
     # NOTE: transitive dependency that breaks other deps
     #       e.g `spacy`'s dependency `click` isn't installed
-    "typer!=0.26.0,!=0.26.1,!=0.26.2",
+    "typer!=0.26.*",
     # transitive dependency that spacy needs but doesn't delcare...
     "click",
 ]

--- a/medcat-den/pyproject.toml
+++ b/medcat-den/pyproject.toml
@@ -36,7 +36,7 @@ dependencies = [
     # NOTE: transitive dependency that breaks other deps
     #       e.g `spacy`'s dependency `click` isn't installed
     "typer!=0.26.*",
-    # transitive dependency that spacy needs but doesn't delcare...
+    # transitive dependency that spacy needs but doesn't declare...
     "click",
 ]
 

--- a/medcat-den/pyproject.toml
+++ b/medcat-den/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     # NOTE: transitive dependency that breaks other deps
     #       e.g `spacy`'s dependency `click` isn't installed
     "typer!=0.26.0,!=0.26.1,!=0.26.2",
+    # transitive dependency that spacy needs but doesn't delcare...
+    "click",
 ]
 
 [project.optional-dependencies]

--- a/medcat-plugins/embedding-linker/pyproject.toml
+++ b/medcat-plugins/embedding-linker/pyproject.toml
@@ -62,6 +62,8 @@ dependencies = [
   # NOTE: transitive dependency that breaks other deps
   #       e.g `spacy`'s dependency `click` isn't installed
   "typer!=0.26.0,!=0.26.1,!=0.26.2",
+  # transitive dependency that spacy needs but doesn't delcare...
+  "click",
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/medcat-plugins/embedding-linker/pyproject.toml
+++ b/medcat-plugins/embedding-linker/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
   # NOTE: transitive dependency that breaks other deps
   #       e.g `spacy`'s dependency `click` isn't installed
   "typer!=0.26.*",
-  # transitive dependency that spacy needs but doesn't delcare...
+  # transitive dependency that spacy needs but doesn't declare...
   "click",
 ]
 

--- a/medcat-plugins/embedding-linker/pyproject.toml
+++ b/medcat-plugins/embedding-linker/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
   "tqdm",
   # NOTE: transitive dependency that breaks other deps
   #       e.g `spacy`'s dependency `click` isn't installed
-  "typer!=0.26.0,!=0.26.1,!=0.26.2",
+  "typer!=0.26.*",
   # transitive dependency that spacy needs but doesn't delcare...
   "click",
 ]

--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -71,7 +71,9 @@ dependencies = [ # Optional
   # TODO - others
   # NOTE: transitive dependency that breaks other deps
   #       e.g `spacy`'s dependency `click` isn't installed
-  "typer!=0.26.0,!=0.26.1,!=0.26.2",
+  "typer!=0.26.*",
+  # transitive dependency that spacy needs but doesn't delcare...
+  "click",
 ]
 
 # List additional groups of dependencies here (e.g. development

--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -72,7 +72,7 @@ dependencies = [ # Optional
   # NOTE: transitive dependency that breaks other deps
   #       e.g `spacy`'s dependency `click` isn't installed
   "typer!=0.26.*",
-  # transitive dependency that spacy needs but doesn't delcare...
+  # transitive dependency that spacy needs but doesn't declare...
   "click",
 ]
 


### PR DESCRIPTION
This PR will fix this once and for all by explicitly requiring `click`. Related to #505 and #507.

I didn't originally want to add `click` as a dependency since that wasn't the culprit. But `typer` already managed to get a subsequent release in, and as such broke all our installs again. So I'm going to bite the bullet and have it in here still.

EDIT:
Notably, the `typer` constraint isn't actually needed after this change. So may be better off removing it instead of widening it like I did now.