### PR TITLE
build(medcat and medcat-den): Remove runs-on from workflow job that reuses a different workflow

### DIFF
--- a/.github/workflows/medcat-den_release.yml
+++ b/.github/workflows/medcat-den_release.yml
@@ -52,7 +52,6 @@ jobs:
 
   # test-time models for download
   upload-test-models:
-    runs-on: ubuntu-latest
     needs: test-and-publish-to-PyPI
     uses: ./.github/workflows/upload-test-models.yml
     with:

--- a/.github/workflows/medcat-v2_release.yml
+++ b/.github/workflows/medcat-v2_release.yml
@@ -208,7 +208,6 @@ jobs:
 
   # test-time models for download
   upload-test-models:
-    runs-on: ubuntu-latest
     needs: release
     uses: ./.github/workflows/upload-test-models.yml
     with:


### PR DESCRIPTION
This affects `medcat` and `medcat-den`. I had misunderstood how the reusing of these workflows went. But this PR should fix that.