### PR TITLE
Determine admin status based on Keycloak roles

### DIFF
--- a/medcat-trainer/webapp/frontend/src/App.vue
+++ b/medcat-trainer/webapp/frontend/src/App.vue
@@ -105,7 +105,7 @@ export default {
     updateOidcUser () {
       if (this.$keycloak && this.$keycloak.tokenParsed) {
         this.uname = this.$keycloak.tokenParsed.preferred_username || null
-        this.isAdmin = this.$keycloak.tokenParsed?.groups?.includes('/medcattrainer-admins') ?? false
+        this.isAdmin = (this.$keycloak.tokenParsed?.realm_access?.roles ?? []).includes('medcattrainer_superuser')
         this.$http.defaults.headers.common['Authorization'] = `Bearer ${this.$keycloak.token}`
       }
     },

--- a/medcat-trainer/webapp/frontend/src/views/Home.vue
+++ b/medcat-trainer/webapp/frontend/src/views/Home.vue
@@ -112,7 +112,7 @@ export default {
           this.fetchProjects()
       } else if (this.useOidc && this.$keycloak && this.$keycloak.authenticated) {
           this.loginSuccessful = true
-          this.isAdmin = this.$keycloak.tokenParsed?.groups.includes('/medcattrainer-admins') ?? false;
+          this.isAdmin = (this.$keycloak.tokenParsed?.realm_access?.roles ?? []).includes('medcattrainer_superuser')
           this.fetchProjects()
         }
     },


### PR DESCRIPTION
- Implements role-based access control (RBAC) to identify if a user has admin privileges using Keycloak roles.
- Simplifies user role management within medcat-trainer.