### PR TITLE
Clarify model download instructions in README

### DIFF
--- a/medcat-v2/README.md
+++ b/medcat-v2/README.md
@@ -28,7 +28,7 @@ We have 2 public v2 models available:
 
 There are also a number of MedCAT v1 models available that can automatically be converted if required.
 
-To download any of these models, please [follow this link](https://uts.nlm.nih.gov/uts/login?service=https://medcat.sites.er.kcl.ac.uk/auth-callback) (or [this link for API key based download](https://medcat.sites.er.kcl.ac.uk/auth-callback-api)) and sign into your NIH profile / UMLS license. You will then be redirected to the MedCAT model download form. Please complete this form and you will be provided a download link.
+To download any of these models, please [follow this link](https://medcat.sites.er.kcl.ac.uk/auth-callback-api) and sign in using your NIH / UMLS API key. You will then be redirected to the MedCAT model download form. Please complete this form and you will be provided a download link.
 
 While we encourage you use MedCAT v2 and the models in that native format, if you download an older version MedCAT v2 will be able to load it and covnert it to the format it knows. However, the loading process will be considerably longerin those cases.
 


### PR DESCRIPTION
This PR removes the non-functional NIH auth callback link from the MedCAT README.

This link hasn't worked since the rosalind domain was killed (so at least a year now I think). We did reach out to NIH to see if they could update it, but got no response. I think they're currently on very limited funding so that's fair enough on their side to not deal with this.