### PR TITLE
build(medcat-scripts): Fix issue from mistyping of pandas index.

### DIFF
--- a/medcat-scripts/evaluate_mct_export/mct_analysis.py
+++ b/medcat-scripts/evaluate_mct_export/mct_analysis.py
@@ -227,7 +227,7 @@ class MedcatTrainer_export(object):
                            df['last_modified'].dt.day.rename('day'),
                            df['user']]).agg({'count'})  # type: ignore
         data = pd.DataFrame(data)
-        data.columns = data.columns.droplevel()
+        data.columns = cast(pd.MultiIndex, data.columns).droplevel()
         data = data.reset_index(drop=False)
         data['date'] = pd.to_datetime(data[['year', 'month', 'day']])
         if by_user:


### PR DESCRIPTION
This PR is fixing an issue that's surfaced by a  update (3.0.3.260530) where the  is interpreted as  rather than  by . For  the  method would expect an argument, but for  it does not. We know this works in practice since there are multiple tests that call this method explicitly.

For reference, the  issue surfaced in workflow:
```
dquote bquote> evaluate_mct_export/mct_analysis.py:230: error: Missing positional argument "level" in call to "droplevel" of "Index"  [call-arg]
```
