### PR TITLE
fix(medcat-trainer): Fix Try Model bug after medcat V2

### DIFF
--- a/medcat-trainer/docker-compose-dev.yml
+++ b/medcat-trainer/docker-compose-dev.yml
@@ -85,4 +85,4 @@ volumes:
 networks:
   gateway-auth_gateway-net:
     name: ${MCT_GATEWAY_NETWORK_NAME:-gateway-auth_gateway-net}
-    external: true
+    # external: true # Uncomment if using an existing gateway auth network. 

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -777,45 +777,45 @@ def annotate_text(request):
                 logger.warning(f'Failed to get children for CUI {parent_cui}: {e}')
         cuis_set = expanded_cuis
 
-    with temp_changed_config(cat.config.components.linking, 'filters', cuis_set):
+    with temp_changed_config(cat.config.components.linking.filters, 'cuis', cuis_set):
         spacy_doc = cat(message)
 
     ents = []
     anno_tkns = []
     for ent in spacy_doc.linked_ents:
-        cnt = Entity.objects.filter(label=ent.cui).count()
         inc_ent = all(tkn not in anno_tkns for tkn in ent)
-        if inc_ent and cnt != 0:
-            meta_annotations = []
-            if 'meta_cat_meta_anns' in ent.get_available_addon_paths():
-                meta_anns = ent.get_addon_data('meta_cat_meta_anns')
-                for meta_ann_task, pred in meta_anns.items():
-                    # Extract value and confidence from pred
-                    # pred can be a dict, object, or string
-                    if isinstance(pred, dict):
-                        pred_value = pred.get('value', str(pred))
-                        pred_confidence = pred.get('confidence', None)
-                    elif hasattr(pred, 'value'):
-                        pred_value = pred.value
-                        pred_confidence = getattr(pred, 'confidence', None)
-                    else:
-                        pred_value = str(pred)
-                        pred_confidence = None
-                    meta_annotations.append({
-                        'task': meta_ann_task,
-                        'value': pred_value,
-                        'confidence': pred_confidence
-                    })
-            anno_tkns.extend([tkn for tkn in ent])
-            entity = Entity.objects.get(label=ent.cui)
-            ents.append({
-                'entity': entity.id,
-                'value': ent.base.text,
-                'start_ind': ent.base.start_char_index,
-                'end_ind': ent.base.end_char_index,
-                'acc': ent.context_similarity,
-                'meta_annotations': meta_annotations
-            })
+        if not inc_ent:
+            continue
+        entity, _ = Entity.objects.get_or_create(label=ent.cui)
+        meta_annotations = []
+        if 'meta_cat_meta_anns' in ent.get_available_addon_paths():
+            meta_anns = ent.get_addon_data('meta_cat_meta_anns')
+            for meta_ann_task, pred in meta_anns.items():
+                # Extract value and confidence from pred
+                # pred can be a dict, object, or string
+                if isinstance(pred, dict):
+                    pred_value = pred.get('value', str(pred))
+                    pred_confidence = pred.get('confidence', None)
+                elif hasattr(pred, 'value'):
+                    pred_value = pred.value
+                    pred_confidence = getattr(pred, 'confidence', None)
+                else:
+                    pred_value = str(pred)
+                    pred_confidence = None
+                meta_annotations.append({
+                    'task': meta_ann_task,
+                    'value': pred_value,
+                    'confidence': pred_confidence
+                })
+        anno_tkns.extend([tkn for tkn in ent])
+        ents.append({
+            'entity': entity.id,
+            'value': ent.base.text,
+            'start_ind': ent.base.start_char_index,
+            'end_ind': ent.base.end_char_index,
+            'acc': ent.context_similarity,
+            'meta_annotations': meta_annotations
+        })
 
     ents.sort(key=lambda e: e['start_ind'])
     out = {'message': message, 'entities': ents}

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -786,7 +786,6 @@ def annotate_text(request):
         inc_ent = all(tkn not in anno_tkns for tkn in ent)
         if not inc_ent:
             continue
-        entity, _ = Entity.objects.get_or_create(label=ent.cui)
         meta_annotations = []
         if 'meta_cat_meta_anns' in ent.get_available_addon_paths():
             meta_anns = ent.get_addon_data('meta_cat_meta_anns')
@@ -808,8 +807,10 @@ def annotate_text(request):
                     'confidence': pred_confidence
                 })
         anno_tkns.extend([tkn for tkn in ent])
+        entity = Entity.objects.filter(label=ent.cui).first()
         ents.append({
-            'entity': entity.id,
+            'entity': entity.id if entity is not None else -1,
+            'cui': ent.cui,
             'value': ent.base.text,
             'start_ind': ent.base.start_char_index,
             'end_ind': ent.base.end_char_index,

--- a/medcat-trainer/webapp/frontend/src/mixins/ConceptDetailService.js
+++ b/medcat-trainer/webapp/frontend/src/mixins/ConceptDetailService.js
@@ -5,6 +5,10 @@ export default {
   methods: {
     fetchDetail (selectedEnt, cdbSearchIndex, callback) {
       if (selectedEnt && Object.keys(selectedEnt).length) {
+        if (selectedEnt.cui) {
+          this.fetchConcept(selectedEnt, cdbSearchIndex, callback)
+          return
+        }
         const queryEntId = selectedEnt.id
         this.$http.get(`/api/entities/${selectedEnt.entity}/`).then(resp => {
           if (selectedEnt && queryEntId === selectedEnt.id) {


### PR DESCRIPTION
Fixes two issues with the try model page

<img width="1875" height="840" alt="image" src="https://github.com/user-attachments/assets/5efcdeac-b2c7-457a-ae6a-24ad2e65f52e" />

## 500 Error on /api/annotate-text/

Error introduced in this PR

https://github.com/CogStack/cogstack-nlp/pull/309/changes


```
[medcattrainer] AttributeError: 'set' object has no attribute 'check_filters'
[medcattrainer] ERROR 2026-06-10 15:34:57,522 log.py l:253:Internal Server Error: /api/annotate-text/
[medcattrainer] Traceback (most recent call last):
[medcattrainer] File "/home/.venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
[medcattrainer] response = get_response(request)

...
 
[medcattrai
[medcattrainer] response = handler(request, *args, **kwargs)
[medcattrainer] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer] File "/home/.venv/lib/python3.12/site-packages/rest_framework/decorators.py", line 50, in handler
[medcattrainer] return func(*args, **kwargs)
[medcattrainer] ^^^^^^^^^^^^^^^^^^^^
[medcattrainer] File "/home/api/api/views.py", line 781, in annotate_text
[medcattrainer] spacy_doc = cat(message)
[medcattrainer] ^^^^^^^^^^^^
[medcattrainer] File "/home/.venv/lib/python3.12/site-packages/medcat/cat.py", line 114, in __call__
[medcattrainer] doc = self._pipeline.get_doc(text)
[medcattrainer] ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer] File "/home/.venv/lib/python3.12/site-packages/medcat/pipeline/pipeline.py", line 331, in get_doc
```

## No entities returned
Original code then seems to be dependent on each Entity being loaded in already, but it really doesnt have to.

I'm not sure when the Entity table is meant to get loaded, so this is technically a work around, but really it's just simplifying it.

### Current flow:
- Get entities from medcat
-  Check they are loaded into the Entity database, and return Entity IDs to the UI. 
- Filter anything not in the database
- Then in the UI, resolve Entity ID to CUI

### New flow
- Get entities from medcat
- As seemingly an unused step - Check they are loaded into the Entity database, and get the Entity ID. Dont filter
- Return CUIs to the UI
- Then in the UI, dont resolve the CUI again




