### PR TITLE
fix(medcat-trainer): Fix Concepts tab for CDBs with no heirarchy

### DIFF
--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -1064,19 +1064,28 @@ def view_metrics(request, report_id):
         return Response(200)
 
 
+FLAT_CDB_ROOT_CUI = 'Root'
+FLAT_CDB_CHILDREN_LIMIT = 500
+
+
 @api_view(http_method_names=['GET'])
 def cdb_cui_children(request, cdb_id):
     parent_cui = request.GET.get('parent_cui')
     cdb = get_cached_cdb(cdb_id, CDB_MAP)
 
-    # root SNOMED CT code: 138875005
-    # root UMLS code: CUI:
-
-    if cdb.addl_info.get('pt2ch') is None:
-        return HttpResponseBadRequest('Requested MedCAT CDB model does not include parent2child metadata to'
-                                      ' explore a concept hierarchy')
+    if not cdb.addl_info.get('pt2ch'):
+        if parent_cui is None:
+            return Response({'results': [
+                {'cui': FLAT_CDB_ROOT_CUI, 'pretty_name': 'All concepts'},
+            ]})
+        cuis = sorted(cdb.cui2info)[:FLAT_CDB_CHILDREN_LIMIT]
+        return Response({'results': [
+            {'cui': cui, 'pretty_name': cdb.get_name(cui)}
+            for cui in cuis
+        ]})
 
     # currently assumes this is using the SNOMED CT terminology
+    # root SNOMED CT code: 138875005
     try:
         root_term = {'cui': '138875005', 'pretty_name': cdb.cui2info['138875005']['preferred_name']}
         if parent_cui is None:
@@ -1091,13 +1100,31 @@ def cdb_cui_children(request, cdb_id):
 
 @api_view(http_method_names=['GET'])
 def cdb_concept_path(request):
+    """
+    Get the concept path for a given CUI to a parent node.
+
+    If the CDB does not have a concept hierarchy, return a flat list of all concepts under a fake root.
+
+    Else, return the actual tree structure, but we only support SNOMED CT at the moment.
+    """
     cdb_id = int(request.GET.get('cdb_id'))
     cdb = get_cached_cdb(cdb_id, CDB_MAP)
+    cui = request.GET.get('cui')
+    if not cdb.addl_info.get('pt2ch'):
+        return Response({'results': {
+            'node_path': {
+                'cui': FLAT_CDB_ROOT_CUI,
+                'pretty_name': 'All concepts',
+                'children': [{
+                    'cui': cui,
+                    'pretty_name': cdb.get_name(cui),
+                }],
+            },
+            'links': [{'parent': FLAT_CDB_ROOT_CUI, 'child': cui}],
+        }})
     if not cdb.addl_info.get('ch2pt'):
         cdb.addl_info['ch2pt'] = ch2pt_from_pt2ch(cdb)
-    cui = request.GET.get('cui')
     # Again only SNOMED CT is supported
-    # 'cui': '138875005',
     result = snomed_ct_concept_path(cui, cdb)
     return Response({'results': result})
 

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -1158,8 +1158,8 @@ def generate_concept_filter(request):
         # get all children from 'parent' concepts above.
         final_filter = {}
         for cui in cuis:
-            final_filter[cui] = [{'cui': c, 'pretty_name': cdb.cui2info[cui]['preferred_name']} for c in get_all_ch(cui, cdb)
-                                 if c in cdb.cui2info[cui]['preferred_name'] and c != cui]
+            final_filter[cui] = [{'cui': c, 'pretty_name': cdb.get_name(c)} for c in get_all_ch(cui, cdb)
+                                 if c in cdb.cui2info and c != cui]
         resp = {'filter_len': sum(len(f) for f in final_filter.values()) + len(final_filter.keys())}
         if resp['filter_len'] < 10000:
             # only send across concept filters that are small enough to render


### PR DESCRIPTION



### Existing Behavior
When used with a CDB that isn't a full SNOMED one, the concepts tab currently fails silently for the user. The network call gives a 400 "Requested MedCAT CDB model does not include parent2child metadata to explore a concept hierarchy"

<img width="1797" height="870" alt="image" src="https://github.com/user-attachments/assets/4d67f9ad-79f3-4b42-b0ea-851aa9cf9448" />

This change fixes it by supporting a flat tree under a dummy root node. It just returns the first 500 concepts, a limit hardcoded for now


### New Behavior
<img width="1792" height="772" alt="image" src="https://github.com/user-attachments/assets/5efd485e-a250-4d19-bde0-6d9aff7f6352" />
