### PR TITLE
docs(medcat-service): Fix link formatting and add v2 model pack section

### DIFF
--- a/medcat-service/models/examples/examples.md
+++ b/medcat-service/models/examples/examples.md
@@ -1,6 +1,6 @@
 # Example Model Packs
 
-## [example-medcat-v1-model-pack][(models/examples/example-medcat-v1-model-pack.zip)
+## [example-medcat-v1-model-pack](models/examples/example-medcat-v1-model-pack.zip)
 - This model pack is built by running the MedCAT V1 Tutorial Part 3.1.
 - https://github.com/CogStack/cogstack-nlp/blob/main/v1/medcat-tutorials/notebooks/introductory/Part_3_1_Building_a_Concept_Database_and_Vocabulary.ipynb
 
@@ -12,3 +12,8 @@ It isn't a trained model, but has the concepts "Kidney Failure" and "Failure of 
 - Only understands PATIENT for deid in very limited cases
 - Trained using 10k synthetic data of just a few example sentences like "Patient {full} had been diagnosed with acute kidney failure the week before"
 
+
+## [example-medcat-v2-model-pack](models/examples/example-medcat-v2-model-pack.zip)
+- This is a conversion of the example-medcat-v1-model-pack to medcat v2
+
+It isn't a trained model, but has the concepts "Kidney Failure" and "Failure of Kidneys" built in


### PR DESCRIPTION
Fixed the link formatting for the example-medcat-v1-model-pack and added a new section for the example-medcat-v2-model-pack.