### PR TITLE
fix(medcat-trainer): Handle where SOLR contains collections aren't from trainer

### DIFF
--- a/medcat-trainer/webapp/api/api/solr_utils.py
+++ b/medcat-trainer/webapp/api/api/solr_utils.py
@@ -44,7 +44,16 @@ def _cache_solr_collection_schema_types(collection):
     logger.info(f'Retrieving solr schema: {url}')
     try:
         resp = json.loads(requests.get(url).text)
-        cui_type = [n for n in resp['schema']['fields'] if n['name'] == 'cui'][0]['type']
+        cui_type = next(
+            (f['type'] for f in resp['schema']['fields'] if f['name'] == 'cui'),
+            None,
+        )
+        if cui_type is None:
+            logger.debug(
+                'Skipping schema cache for collection %s: no cui field (not a MedCAT Trainer index)',
+                collection,
+            )
+            return
         # just store cui type for the time being
         SOLR_INDEX_SCHEMA[collection] = {'cui': cui_type}
     except ConnectionError as e:

--- a/medcat-trainer/webapp/api/api/tests/test_solr_utils.py
+++ b/medcat-trainer/webapp/api/api/tests/test_solr_utils.py
@@ -53,6 +53,56 @@ class CollectionsAvailableTests(TestCase):
         response = solr_utils.collections_available(['1'])
         self.assertEqual(response.status_code, 500)
 
+    @patch('api.solr_utils.requests.get')
+    def test_ignores_non_medcat_collections_without_cui_field(self, mock_get):
+        # Bitnami Solr helm chart bootstraps a default "my-collection" with no cui field.
+        def side_effect(url, *args, **kwargs):
+            if 'admin/collections' in url:
+                return MagicMock(status_code=200, text=json.dumps({
+                    'collections': ['my-collection', 'my_id_1'],
+                }))
+            if 'my-collection' in url:
+                return MagicMock(text=json.dumps({
+                    'schema': {'fields': [{'name': 'id', 'type': 'string'}]},
+                }))
+            return MagicMock(text=json.dumps({
+                'schema': {'fields': [{'name': 'cui', 'type': 'string'}]},
+            }))
+
+        mock_get.side_effect = side_effect
+
+        response = solr_utils.collections_available(['1'])
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.data['results']['1'])
+        self.assertNotIn('my-collection', solr_utils.SOLR_INDEX_SCHEMA)
+        self.assertEqual(solr_utils.SOLR_INDEX_SCHEMA['my_id_1'], {'cui': 'string'})
+
+
+@override_settings(MEDIA_ROOT='/tmp/mct-tests-solr')
+class CacheSolrCollectionSchemaTypesTests(TestCase):
+    def setUp(self):
+        solr_utils.SOLR_INDEX_SCHEMA.clear()
+
+    @patch('api.solr_utils.requests.get')
+    def test_skips_cache_when_cui_field_missing(self, mock_get):
+        mock_get.return_value = MagicMock(text=json.dumps({
+            'schema': {'fields': [{'name': 'id', 'type': 'string'}]},
+        }))
+
+        solr_utils._cache_solr_collection_schema_types('my-collection')
+
+        self.assertNotIn('my-collection', solr_utils.SOLR_INDEX_SCHEMA)
+
+    @patch('api.solr_utils.requests.get')
+    def test_caches_cui_type_when_field_present(self, mock_get):
+        mock_get.return_value = MagicMock(text=json.dumps({
+            'schema': {'fields': [{'name': 'cui', 'type': 'plongs'}]},
+        }))
+
+        solr_utils._cache_solr_collection_schema_types('my_id_1')
+
+        self.assertEqual(solr_utils.SOLR_INDEX_SCHEMA['my_id_1'], {'cui': 'plongs'})
+
 
 @override_settings(MEDIA_ROOT='/tmp/mct-tests-solr')
 class SearchCollectionTests(TestCase):


### PR DESCRIPTION

This fix should sort out the CDB import in k8s. Trainer right now is failing if SOLR is used for anything else - every collection must have the field CUI in the current impl. In k8s it initialises a SOLR collection "my-collection" that doesnt have a field called CUI so it breaks it.

Right now when I save a project it hits this error.

```
[medcattrainer] INFO 2026-06-11 14:12:10,012 solr_utils.py l:46:Retrieving all SOLR collections: http://cogstack-solr:8983/solr/admin/collections?action=LIST
[medcattrainer] INFO 2026-06-11 14:12:10,024 solr_utils.py l:32:Retrieving solr schema: http://cogstack-solr:8983/solr/my-collection/schema
[medcattrainer] ERROR 2026-06-11 14:12:10,040 views.py l:862:Failed to search for concept_search_index. Solr Search Service not available
[medcattrainer] Traceback (most recent call last):
[medcattrainer]   File "/home/api/api/views.py", line 860, in concept_search_index_available
[medcattrainer]     return collections_available(cdb_ids)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/usr/local/lib/python3.12/contextlib.py", line 81, in inner
[medcattrainer]     return func(*args, **kwds)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/api/api/solr_utils.py", line 52, in collections_available
[medcattrainer]     _cache_solr_collection_schema_types(col)
[medcattrainer]   File "/usr/local/lib/python3.12/contextlib.py", line 81, in inner
[medcattrainer]     return func(*args, **kwds)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/api/api/solr_utils.py", line 35, in _cache_solr_collection_schema_types
[medcattrainer]     cui_type = [n for n in resp['schema']['fields'] if n['name'] == 'cui'][0]['type']
[medcattrainer]                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
[medcattrainer] IndexError: list index out of range
[medcattrainer] Internal Server Error: /api/concept-db-search-index-created/
[medcattrainer] ERROR 2026-06-11 14:12:10,042 log.py l:253:Internal Server Error: /api/concept-db-search-index-created/
```

The fix is to make it ignore collections that dont have the field 'cui' present.

I'll separately update the helm chart to also not make the collection, but this is the real fix here