### PR TITLE
ci: set the version number before building the package in medcat-trainer_ci

### DIFF
--- a/.github/workflows/medcat-trainer_ci.yml
+++ b/.github/workflows/medcat-trainer_ci.yml
@@ -73,14 +73,21 @@ jobs:
             medcat-trainer/client/htmlcov
           if-no-files-found: ignore
 
+      - name: Set release version from tag
+        if: startsWith(github.ref, 'refs/tags')
+        run: |
+          VERSION="${GITHUB_REF_NAME#medcat-trainer/v}"
+          sed -i "s/^version = .*/version = \"$VERSION\"/" client/pyproject.toml
+          echo "Release version: $VERSION"
+
+      - name: Set dev version for TestPyPI
+        if: github.ref == 'refs/heads/main'
+        run: sed -i "s/^version = .*/version = \"0.0.0.dev$(date +%s)\"/" client/pyproject.toml
+
       - name: Build client package
         run: |
           cd client
           python -m build
-
-      - name: Bump version for TestPyPI
-        if: github.ref == 'refs/heads/main'
-        run: sed -i "s/^version = .*/version = \"1.0.0.dev$(date +%s)\"/" client/pyproject.toml
 
       - name: Publish dev distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -93,7 +100,6 @@ jobs:
       - name: Publish production distribution to PyPI
         if: startsWith(github.ref, 'refs/tags') && ! github.event.release.prerelease
         uses: pypa/gh-action-pypi-publish@release/v1
-        continue-on-error: true
         with:
           packages_dir: medcat-trainer/client/dist
 

--- a/medcat-trainer/client/pyproject.toml
+++ b/medcat-trainer/client/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "medcattrainer-client"
-version = "1.3.0"
+version = "1.4.0"
 description = "Python client for interacting with a MedCATTrainer instance"
 readme = "client/README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
### Summary

- Ensure version number is set before building the package to avoid upload issues with duplicate version numbers.
- Prevents from silently failing to upload a package with the same version number each time
