### PR TITLE
fix(medcat-service): Gradio offline usage fix by updating version

### DIFF
--- a/medcat-service/docs/setup/configuration.md
+++ b/medcat-service/docs/setup/configuration.md
@@ -28,6 +28,7 @@ The following environment variables are available for tailoring the MedCAT Servi
 - `APP_ENABLE_DEMO_UI` - Enable the demo user interface to try models. (Default: `False`)
 - `APP_DEMO_UI_PATH` - Customise the path of the demo UI. (Default: `/`)
 - `APP_USE_CDN` - Load Swagger UI and ReDoc assets from a CDN. (Default: `True`) Set to `False` to serve docs from bundled static files instead. This allows the docs UI to work for offline browsers.
+- `GRADIO_ANALYTICS_ENABLED` - Optionally disable the telemetry of gradio when using the demo UI
 
 ### Shared Memory (`DOCKER_SHM_SIZE`)
 

--- a/medcat-service/requirements.txt
+++ b/medcat-service/requirements.txt
@@ -6,7 +6,7 @@ medcat[meta-cat,spacy,deid]~=2.8.0
 # pinned because of issues with de-id models and past models (it will not do any de-id)
 transformers>=4.34.0,<5.0.0
 requests==2.33.0
-fastapi[standard]==0.137.1
+fastapi[standard]==0.136.3
 pydantic>=2.11.10,<2.12.5
 pydantic-settings==2.10.1
 gradio[mcp]==6.17.3

--- a/medcat-service/requirements.txt
+++ b/medcat-service/requirements.txt
@@ -6,11 +6,11 @@ medcat[meta-cat,spacy,deid]~=2.8.0
 # pinned because of issues with de-id models and past models (it will not do any de-id)
 transformers>=4.34.0,<5.0.0
 requests==2.33.0
-fastapi[standard]==0.128.0
+fastapi[standard]==0.137.1
 pydantic>=2.11.10,<2.12.5
 pydantic-settings==2.10.1
-gradio[mcp]==6.7.0
-prometheus-fastapi-instrumentator==7.1.0
+gradio[mcp]==6.17.3
+prometheus-fastapi-instrumentator==8.0.0
 opentelemetry-distro[otlp]==0.60b0
 opentelemetry-instrumentation==0.60b0
 opentelemetry-resource-detector-containerid==0.60b0


### PR DESCRIPTION
This bumps gradio, in order to get changes from this PR gradio-app/gradio/pull/13463

## Current behavior

Current gradio version was making these calls on startup:

Google Fonts — stylesheet for the default theme font: https://fonts.googleapis.com/css2?family=Source+Sans+Pro:wght@400;600&display=swap

cdnjs (iframe-resizer) — script from Gradio’s index.html: https://cdnjs.cloudflare.com/ajax/libs/iframe-resizer/4.3.1/iframeResizer.contentWindow.min.js

## New behavior

All calls are now local only. When running offline, there are now no more failing network calls