### PR TITLE
ci(medcat-service): Change GHA to build and test the image before push

### DIFF
--- a/.github/workflows/medcat-service_docker.yml
+++ b/.github/workflows/medcat-service_docker.yml
@@ -17,11 +17,9 @@ defaults:
   run:
     working-directory: ./medcat-service
 jobs:
-  build:
+  build-test-push:
     if: github.event.pull_request.user.login != 'dependabot[bot]' && github.repository == 'CogStack/cogstack-nlp'
     runs-on: ubuntu-latest
-    outputs:
-      image_version: ${{ steps.meta.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -62,7 +60,8 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
-            type=sha
+            # Highest priority so version output is the immutable sha tag (not pr-123 etc.)
+            type=sha,priority=2000
             # Create version tag based on tag prefix
             type=match,pattern=medcat-service/v(\d+\.\d+\.\d+),group=1
           flavor: latest=false
@@ -70,8 +69,32 @@ jobs:
       - name: Make medact-v2 available within build
         run: cp -r ../medcat-v2 medcat-v2
 
-      - name: Build and push Docker MedCATservice image
+      - name: Build Docker MedCATservice image for testing
         id: docker_build
+        uses: docker/build-push-action@v7
+        with:
+          context: ./medcat-service/
+          load: true # https://docs.docker.com/build/ci/github-actions/test-before-push/
+          allow: network.host
+          tags: cogstacksystems/medcat-service:test
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=registry,ref=cogstacksystems/medcat-service:buildcache
+          cache-to: type=registry,ref=cogstacksystems/medcat-service:buildcache,mode=max
+          build-args: |
+            REINSTALL_CORE_FROM_LOCAL=true
+
+      - name: Run integration tests (matrix variants)
+        run: |
+          export IMAGE_TAG=test
+          for variant in v1 v2 DeID; do
+            echo "🧪 Running Examples test for variant: ${variant}"
+            bash scripts/test_examples.sh "${variant}"
+          done
+
+      - name: Report test result
+        run: echo "✅ Integration test PASSED"
+
+      - name: Push Docker MedCATservice image
         uses: docker/build-push-action@v7
         with:
           context: ./medcat-service/
@@ -83,7 +106,7 @@ jobs:
           cache-to: type=registry,ref=cogstacksystems/medcat-service:buildcache,mode=max
           build-args: |
             REINSTALL_CORE_FROM_LOCAL=true
-      
+
       - name: Extract metadata (tags, labels) for Docker MedCATservice-gpu
         id: meta-gpu
         uses: docker/metadata-action@v6
@@ -101,8 +124,6 @@ jobs:
             # Create version tag based on tag prefix
             type=match,pattern=medcat-service/v(\d+\.\d+\.\d+),group=1
           flavor: latest=false
-          build-args: |
-            REINSTALL_CORE_FROM_LOCAL=true
 
       - name: Build and push Docker Jupyter singleuser image with GPU support
         id: docker_build_gpu
@@ -118,34 +139,7 @@ jobs:
           cache-to: type=registry,ref=cogstacksystems/medcat-service-gpu:buildcache,mode=max
           build-args: |
             REINSTALL_CORE_FROM_LOCAL=true
-          
+
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}
         working-directory: "./"
-  integration_test:
-    runs-on: ubuntu-latest
-    needs: build
-    strategy:
-      matrix:
-        variant: [v1, v2, DeID]
-    steps:
-
-      - name: Check out code
-        uses: actions/checkout@v6
-
-      - name: Run Test with example model pack
-        run: |
-          echo "🧪 Running Examples test..."
-          export IMAGE_TAG=${{ needs.build.outputs.image_version }} # Improve by running exact digest instead
-          echo "Running with image tag ${IMAGE_TAG} and variant ${{ matrix.variant }}"
-          bash scripts/test_examples.sh ${{ matrix.variant }}
-          
-      - name: Report test result
-        if: always()
-        run: |
-          if [ $? -eq 0 ]; then
-            echo "✅ Integration test PASSED"
-          else
-            echo "❌ Integration test FAILED"
-            exit 1
-          fi

--- a/.github/workflows/medcat-service_docker.yml
+++ b/.github/workflows/medcat-service_docker.yml
@@ -90,9 +90,6 @@ jobs:
             bash scripts/test_examples.sh "${variant}"
           done
 
-      - name: Report test result
-        run: echo "✅ Integration test PASSED"
-
       - name: Push Docker MedCATservice image
         uses: docker/build-push-action@v7
         with:

--- a/.github/workflows/medcat-service_docker.yml
+++ b/.github/workflows/medcat-service_docker.yml
@@ -60,8 +60,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
-            # Highest priority so version output is the immutable sha tag (not pr-123 etc.)
-            type=sha,priority=2000
+            type=sha
             # Create version tag based on tag prefix
             type=match,pattern=medcat-service/v(\d+\.\d+\.\d+),group=1
           flavor: latest=false

--- a/medcat-service/docker/run_example_simple.sh
+++ b/medcat-service/docker/run_example_simple.sh
@@ -17,7 +17,7 @@ fi
 # To run in a container run "export LOCALHOST_NAME=host.docker.internal"
 LOCALHOST_NAME=${LOCALHOST_NAME:-localhost}
 
-echo "Running docker-compose"
+echo "Running docker-compose with ${DOCKER_COMPOSE_FILE}"
 docker compose -f ${DOCKER_COMPOSE_FILE} up -d
 
 echo "Running test"

--- a/medcat-service/scripts/test_examples.sh
+++ b/medcat-service/scripts/test_examples.sh
@@ -7,18 +7,26 @@ if [ -n "$IMAGE_TAG" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VARIANT=$1
 
+if [ "$VARIANT" = "v1" ]; then
+  COMPOSE_FILE="docker-compose.example.v1.yml"
+elif [ "$VARIANT" = "DeID" ]; then
+  COMPOSE_FILE="docker-compose.example.deid.yml"
+else
+  COMPOSE_FILE="docker-compose.example.yml"
+fi
 
-cd ${SCRIPT_DIR}/../docker
-bash run_example_simple.sh $1
+cd "${SCRIPT_DIR}/../docker"
+bash run_example_simple.sh "${VARIANT}"
 
-# Check if health check was successful
 if [ $? -eq 0 ]; then
     echo "✅ Success! Medcat service passed integration tests"
-    docker compose -f docker-compose.example.yml down
+    docker compose -f "${COMPOSE_FILE}" down
     exit 0
 else
     echo "❌ Failure. Medcat service failed tests"
+    docker compose -f "${COMPOSE_FILE}" down
     exit 1
 fi
 


### PR DESCRIPTION
I think this fixes another PR is why I'm doing it now

Change is to follow this pattern, make a "test" image that is local only, test it, then push it to dockerhub afterwards

https://docs.docker.com/build/ci/github-actions/test-before-push/

This pattern already used in other builds