### PR TITLE
hotfix(medcat): Disable config train at load time

### DIFF
--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -125,9 +125,9 @@ class CAT(AbstractSerialisable):
         """
         # pass
         if self.config.components.linking.train:
-            logger.info("Training was enabled during %s. "
-                        "It was automatically disabled.",
-                        stage)
+            logger.debug("Training was enabled during %s. "
+                         "It was automatically disabled.",
+                         stage)
             self.config.components.linking.train = False
 
     @overload

--- a/medcat-v2/medcat/cat.py
+++ b/medcat-v2/medcat/cat.py
@@ -116,7 +116,7 @@ class CAT(AbstractSerialisable):
             self.usage_monitor.log_inference(len(text), len(doc.linked_ents))
         return doc
 
-    def _ensure_not_training(self) -> None:
+    def _ensure_not_training(self, stage: str = 'inference') -> None:
         """Method to ensure config is not set to train.
 
         `config.components.linking.train` should only be True while training
@@ -125,8 +125,9 @@ class CAT(AbstractSerialisable):
         """
         # pass
         if self.config.components.linking.train:
-            logger.warning("Training was enabled during inference. "
-                           "It was automatically disabled.")
+            logger.info("Training was enabled during %s. "
+                        "It was automatically disabled.",
+                        stage)
             self.config.components.linking.train = False
 
     @overload
@@ -882,6 +883,8 @@ class CAT(AbstractSerialisable):
             raise ValueError(f"Unable to load CAT. Got: {cat}")
         # reset mapped ontologies at load time but after CDB load
         cat._set_and_get_mapped_ontologies()
+        # ensure training is disabled
+        cat._ensure_not_training('model load')
         return cat
 
     @classmethod

--- a/medcat-v2/tests/test_cat.py
+++ b/medcat-v2/tests/test_cat.py
@@ -120,12 +120,31 @@ class ModelLoadIWithHiddenFilesTests(unittest.TestCase):
 
 class TrainedModelTests(unittest.TestCase):
     TRAINED_MODEL_PATH = EXAMPLE_MODEL_PACK_ZIP
+    CONFIG_DICT = None
 
     @classmethod
     def setUpClass(cls):
-        cls.model = cat.CAT.load_model_pack(cls.TRAINED_MODEL_PATH)
-        if cls.model.config.components.linking.train:
-            cls.model.config.components.linking.train = False
+        cls.model = cat.CAT.load_model_pack(
+            cls.TRAINED_MODEL_PATH, config_dict=cls.CONFIG_DICT)
+
+
+class ModelLoadInitTests(TrainedModelTests):
+    # NOTE: as of writing, the saved model
+    #       has config.components.linking.train = True already
+    #       set but in case we change the model to a new one
+    #       this ensures that the "raw" output is always set to True
+    CONFIG_DICT = {
+        "components": {
+            "linking": {
+                "train": True,
+            }
+        }
+    }
+
+    def test_model_is_not_training(self):
+        self.assertFalse(
+            self.model.config.components.linking.train
+        )
 
 
 class ConfigMergeTests(unittest.TestCase):


### PR DESCRIPTION
This PR sets `config.components.linking.train` to `False` at load time.

Some models may have been saved with this set to `True`. And as of v2.8 (specifically #414) this can cause issues since that method of running training is no longer used.

There's also an added test that makes sure the loaded model has this config option disabled. (NOTE: the model that's in the repo has this problem so the test previously set this to `False` itself, but I've now removed this from the test class setup).

I also checked that this test fails in the main branch (i.e without the change from the first commit).

PS:
Just to be clear, this has to do with the config option that was previously used for self-supervised training. The process was to set `*.train = True` and run inference and then the vocab based linker would perform training within the inference step. The expected new approach is more explicit and does not use this config option. **So all models can still be trained** - both unsupervised and supervised.