### PR TITLE
test(medcat-trainer): Add model inference test with config-train set to true

### DIFF
--- a/.github/workflows/medcat-trainer_ci.yml
+++ b/.github/workflows/medcat-trainer_ci.yml
@@ -197,7 +197,6 @@ jobs:
         if: matrix.medcat-source == 'local'
         run: |
           cd webapp
-          uv venv .venv
           uv pip install --editable "../../medcat-v2[meta-cat,spacy,rel-cat,deid,dict-ner]"
 
       - name: Run Django tests with coverage

--- a/.github/workflows/medcat-trainer_ci.yml
+++ b/.github/workflows/medcat-trainer_ci.yml
@@ -148,6 +148,11 @@ jobs:
 
   test-backend:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        medcat-source:
+          - released   # current behaviour, pins to lockfile
+          - local      # tests against ../medcat-v2
     steps:
       - name: Checkout main
         uses: actions/checkout@v6
@@ -175,6 +180,12 @@ jobs:
         run: |
           cd webapp
           uv sync --frozen
+
+      - name: Swap in local medcat (local matrix leg only)
+        if: matrix.medcat-source == 'local'
+        run: |
+          cd webapp
+          uv pip install --editable ../medcat-v2
 
       - name: Ensure pip inside uv environment
         run: |

--- a/.github/workflows/medcat-trainer_ci.yml
+++ b/.github/workflows/medcat-trainer_ci.yml
@@ -184,7 +184,6 @@ jobs:
       - name: Swap in local medcat (local matrix leg only)
         if: matrix.medcat-source == 'local'
         run: |
-          cd webapp
           uv pip install --editable ../medcat-v2
 
       - name: Ensure pip inside uv environment

--- a/.github/workflows/medcat-trainer_ci.yml
+++ b/.github/workflows/medcat-trainer_ci.yml
@@ -181,12 +181,6 @@ jobs:
           cd webapp
           uv sync --frozen
 
-      - name: Swap in local medcat (local matrix leg only)
-        if: matrix.medcat-source == 'local'
-        run: |
-          uv venv .venv
-          uv pip install --editable "../medcat-v2[meta-cat,spacy,rel-cat,deid,dict-ner]"
-
       - name: Ensure pip inside uv environment
         run: |
           cd webapp
@@ -198,6 +192,13 @@ jobs:
           cd webapp
           uv run python -m spacy download en_core_web_md
 
+      - name: Swap in local medcat (local matrix leg only)
+        # NOTE: doing this after all of the above to avoid re-installing
+        if: matrix.medcat-source == 'local'
+        run: |
+          uv venv .venv
+          uv pip install --editable "../medcat-v2[meta-cat,spacy,rel-cat,deid,dict-ner]"
+
       - name: Run Django tests with coverage
         env:
           DB_ENGINE: sqlite3
@@ -206,9 +207,10 @@ jobs:
         run: |
           cd webapp/api
           # NOTE: no-sync allows usage of local install if required
+          #       but shouldn't affect other installs since it should be in sync
           uv run --no-sync --with "coverage[toml]" coverage run manage.py test
-          uv run --with "coverage[toml]" coverage xml -o coverage.xml
-          uv run --with "coverage[toml]" coverage html -d htmlcov
+          uv run --no-sync --with "coverage[toml]" coverage xml -o coverage.xml
+          uv run --no-sync --with "coverage[toml]" coverage html -d htmlcov
 
       - name: Backend coverage summary
         if: always()

--- a/.github/workflows/medcat-trainer_ci.yml
+++ b/.github/workflows/medcat-trainer_ci.yml
@@ -205,7 +205,8 @@ jobs:
           DEBUG: 1
         run: |
           cd webapp/api
-          uv run --with "coverage[toml]" coverage run manage.py test
+          # NOTE: no-sync allows usage of local install if required
+          uv run --no-sync --with "coverage[toml]" coverage run manage.py test
           uv run --with "coverage[toml]" coverage xml -o coverage.xml
           uv run --with "coverage[toml]" coverage html -d htmlcov
 

--- a/.github/workflows/medcat-trainer_ci.yml
+++ b/.github/workflows/medcat-trainer_ci.yml
@@ -184,6 +184,7 @@ jobs:
       - name: Swap in local medcat (local matrix leg only)
         if: matrix.medcat-source == 'local'
         run: |
+          uv venv .venv
           uv pip install --editable ../medcat-v2
 
       - name: Ensure pip inside uv environment

--- a/.github/workflows/medcat-trainer_ci.yml
+++ b/.github/workflows/medcat-trainer_ci.yml
@@ -196,8 +196,9 @@ jobs:
         # NOTE: doing this after all of the above to avoid re-installing
         if: matrix.medcat-source == 'local'
         run: |
+          cd webapp
           uv venv .venv
-          uv pip install --editable "../medcat-v2[meta-cat,spacy,rel-cat,deid,dict-ner]"
+          uv pip install --editable "../../medcat-v2[meta-cat,spacy,rel-cat,deid,dict-ner]"
 
       - name: Run Django tests with coverage
         env:

--- a/.github/workflows/medcat-trainer_ci.yml
+++ b/.github/workflows/medcat-trainer_ci.yml
@@ -185,7 +185,7 @@ jobs:
         if: matrix.medcat-source == 'local'
         run: |
           uv venv .venv
-          uv pip install --editable ../medcat-v2
+          uv pip install --editable "../medcat-v2[meta-cat,spacy,rel-cat,deid,dict-ner]"
 
       - name: Ensure pip inside uv environment
         run: |

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -114,5 +114,5 @@ class ModelInferenceTests(TestCase):
         self.assertEqual(response.data["message"], "Documents prepared successfully")
 
         # The document should now be in prepared_documents
-        self.assertTre(self.project.prepared_documents.all())
+        self.assertTrue(self.project.prepared_documents.all())
         self.assertEqual(len(self.project.prepared_documents), len(doc_ids))

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -1,0 +1,72 @@
+import os
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from medcat.cat import CAT
+
+from api.api.models import ProjectAnnotateEntities, Document
+
+
+MODEL_PATH = os.path.join(
+    os.path.dirname(__file__),
+    "..", "..", "..", "..", "..",
+    "../medcat-test-models",
+    "mct2_model_pack_train_true.zip"
+)
+
+
+class ModelInferenceTests(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Load once for the whole test class — it's expensive
+        cls.cat = CAT.load_model_pack(MODEL_PATH)
+
+    def setUp(self):
+        # A real user — the view reads request.user
+        self.user = User.objects.create_user(username="testuser", password="password")
+        self.client.force_login(self.user)
+
+        # Minimal project setup
+        self.project = ProjectAnnotateEntities.objects.create(
+            name="Test Project",
+            cuis=None,
+            cuis_file=None,
+            use_model_service=False,
+            deid_model_annotation=False,
+        )
+
+        # A document with some text the model can run on
+        self.document = Document.objects.create(
+            name="Test Doc",
+            text="The patient had sever kidney failure.",
+        )
+
+    @contextmanager
+    def use_provided_model(self):
+        with patch("api.views.get_medcat", return_value=self.cat):
+            yield
+
+    def test_can_use_model_for_inference(self):
+        with self.use_provided_model():
+            response = self.client.post(
+                reverse("prepare_documents"),  # adjust to your actual URL name
+                data={
+                    "document_ids": [self.document.id],
+                    "project_id": self.project.id,
+                    "force": 0,
+                    "update": 0,
+                },
+                content_type="application/json",
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["message"], "Documents prepared successfully")
+
+        # The document should now be in prepared_documents
+        self.assertIn(self.document, self.project.prepared_documents.all())

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -36,6 +36,7 @@ class ModelInferenceTests(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         cls._create_symlink()
+        cls._create_dataset_file()
         # Load once for the whole test class — it's expensive
         cls.cat = CAT.load_model_pack(MODEL_PATH)
 

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -48,7 +48,7 @@ class ModelInferenceTests(TestCase):
         # dataset
         self.dataset = Dataset.objects.create(
             name="fake_dataset",
-            original_file=__file__,
+            original_file="some_file.csv",
             description="Fake Dataset"
         )
 

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 
 from medcat.cat import CAT
 
-from api.api.models import ProjectAnnotateEntities, Document
+from api.models import ProjectAnnotateEntities, Document
 
 
 MODEL_PATH = os.path.join(

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -89,7 +89,7 @@ class ModelInferenceTests(TestCase):
     def test_can_use_model_for_inference(self):
         with self.use_provided_model():
             response = self.client.post(
-                reverse("prepare_documents"),  # adjust to your actual URL name
+                reverse("api/prepare_documents"),  # adjust to your actual URL name
                 data={
                     "document_ids": [self.document.id],
                     "project_id": self.project.id,

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -13,7 +13,7 @@ from api.models import ProjectAnnotateEntities, Document
 
 MODEL_PATH = os.path.join(
     os.path.dirname(__file__),
-    "..", "..", "..", "..", "..",
+    "..", "..", "..", "..",
     "../medcat-test-models",
     "mct2_model_pack_train_true.zip"
 )

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -60,6 +60,7 @@ class ModelInferenceTests(TestCase):
         self.document = Document.objects.create(
             name="Test Doc",
             text="The patient had sever kidney failure.",
+            dataset_id=-1,
         )
 
     @contextmanager

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -46,6 +46,7 @@ class ModelInferenceTests(TestCase):
     @classmethod
     def _create_dataset_file(cls):
         df = pd.DataFrame(cls.DS_CONTENT, columns=['id', 'text'])
+        df.to_csv(cls.DS_FILE)
 
     def setUp(self):
         # A real user — the view reads request.user

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -10,7 +10,7 @@ from django.urls import reverse
 
 from medcat.cat import CAT
 
-from api.models import ProjectAnnotateEntities, ModelPack, Dataset
+from api.models import Document, ProjectAnnotateEntities, ModelPack, Dataset
 
 
 RAW_MODEL_PATH = os.path.join(
@@ -88,10 +88,11 @@ class ModelInferenceTests(TestCase):
 
     def test_can_use_model_for_inference(self):
         with self.use_provided_model():
+            doc_ids = [doc.id for doc in Document.objects.all()]
             response = self.client.post(
                 "/api/prepare-documents/",
                 data={
-                    "document_ids": [self.document.id],
+                    "document_ids": doc_ids,
                     "project_id": self.project.id,
                     "force": 0,
                     "update": 0,
@@ -104,3 +105,4 @@ class ModelInferenceTests(TestCase):
 
         # The document should now be in prepared_documents
         self.assertTrye(self.project.prepared_documents.all())
+        self.assertEqual(len(self.project.prepared_documents), len(doc_ids))

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -19,14 +19,17 @@ RAW_MODEL_PATH = os.path.join(
     "medcat-test-models",
     "mct2_model_pack_train_true.zip"
 )
-MODEL_PATH = os.path.join(
+MEDIA_PATH = os.path.join(
     os.path.dirname(__file__),
-    "..", "..", "media", "fake_model_pack.zip"
+    "..", "..", "media"
+)
+MODEL_PATH = os.path.join(
+    MEDIA_PATH, "fake_model_pack.zip"
 )
 
 
 class ModelInferenceTests(TestCase):
-    DS_FILE = "example_ds.csv"
+    DS_FILE = os.path.join(MEDIA_PATH, "example_ds.csv")
     DS_CONTENT = ((-1, "The patient had severe kidney failure"))
 
     @classmethod

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -53,6 +53,7 @@ class ModelInferenceTests(TestCase):
             cuis_file=None,
             use_model_service=False,
             deid_model_annotation=False,
+            dataset_id=-1,
         )
 
         # A document with some text the model can run on

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -1,19 +1,17 @@
 import os
 from contextlib import contextmanager
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 import shutil
 
-import pandas as pd
-
-from django.contrib.auth.models import User
 from django.test import TestCase
 import unittest
 from rest_framework.test import APIClient
+from ._helpers import create_dataset, create_user, create_document
 
 import medcat
 from medcat.cat import CAT
 
-from api.models import Document, ProjectAnnotateEntities, ModelPack, Dataset
+from api.models import Document, ProjectAnnotateEntities, ModelPack
 
 
 RAW_MODEL_PATH = os.path.join(
@@ -35,15 +33,11 @@ HAS_KNOWN_FAILURE = medcat.__version__ in ("2.8.0", "2.8.1", "2.8.2", "2.8.3")
 
 
 class ModelInferenceTests(TestCase):
-    DS_FILE = os.path.join(MEDIA_PATH, "example_ds.csv")
-    DS_CONTENT = (("T0", "The patient had severe kidney failure"),)
-    DS_COLUMNS = ("name", "text")
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
         cls._copy_model()
-        cls._create_dataset_file()
         # Load once for the whole test class — it's expensive
         cls.cat = CAT.load_model_pack(MODEL_PATH)
 
@@ -53,7 +47,6 @@ class ModelInferenceTests(TestCase):
         folder_path = MODEL_PATH.removesuffix(".zip")
         if os.path.exists(folder_path):
             shutil.rmtree(folder_path)
-        os.remove(cls.DS_FILE)
 
     @classmethod
     def _copy_model(cls):
@@ -62,14 +55,9 @@ class ModelInferenceTests(TestCase):
             MODEL_PATH
         )
 
-    @classmethod
-    def _create_dataset_file(cls):
-        df = pd.DataFrame(cls.DS_CONTENT, columns=cls.DS_COLUMNS)
-        df.to_csv(cls.DS_FILE)
-
     def setUp(self):
         # A real user — the view reads request.user
-        self.user = User.objects.create_user(username="testuser", password="password", is_staff=True)
+        self.user = create_user(username="testuser", password="password", is_staff=True)
         self.client = APIClient()
         self.client.force_authenticate(self.user)
 
@@ -79,11 +67,9 @@ class ModelInferenceTests(TestCase):
         )
 
         # dataset
-        self.dataset = Dataset.objects.create(
-            name="fake_dataset",
-            original_file=self.DS_FILE,
-            description="Fake Dataset"
-        )
+        self.dataset = create_dataset("FAKE-ds")
+        # NOTE: self.dataset will be used to map to the dataset
+        self.document = create_document(self, "DOC1", "Patient has severe kidney failure")
 
         # Minimal project setup
         self.project = ProjectAnnotateEntities.objects.create(

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -7,8 +7,10 @@ import pandas as pd
 
 from django.contrib.auth.models import User
 from django.test import TestCase
+import unittest
 from rest_framework.test import APIClient
 
+import medcat
 from medcat.cat import CAT
 
 from api.models import Document, ProjectAnnotateEntities, ModelPack, Dataset
@@ -27,6 +29,9 @@ MEDIA_PATH = os.path.join(
 MODEL_PATH = os.path.join(
     MEDIA_PATH, "fake_model_pack.zip"
 )
+
+
+HAS_KNOWN_FAILURE = medcat.__version__ in ("2.8.0", "2.8.1", "2.8.2", "2.8.3")
 
 
 class ModelInferenceTests(TestCase):
@@ -96,6 +101,7 @@ class ModelInferenceTests(TestCase):
         with patch("api.views.get_medcat", return_value=self.cat):
             yield
 
+    @unittest.skipIf(HAS_KNOWN_FAILURE, "Known to fail in 2.8.* (<2.8.4), specfically")
     def test_can_use_model_for_inference(self):
         with self.use_provided_model():
             doc_ids = [doc.id for doc in Document.objects.all()]

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 
 from medcat.cat import CAT
 
-from api.models import ProjectAnnotateEntities, Document, ModelPack
+from api.models import ProjectAnnotateEntities, Document, ModelPack, Dataset
 
 
 RAW_MODEL_PATH = os.path.join(
@@ -45,6 +45,13 @@ class ModelInferenceTests(TestCase):
             model_pack=MODEL_PATH,
         )
 
+        # dataset
+        self.dataset = Dataset.objects.create(
+            name="fake_dataset",
+            original_file=__file__,
+            description="Fake Dataset"
+        )
+
         # Minimal project setup
         self.project = ProjectAnnotateEntities.objects.create(
             name="Test Project",
@@ -53,14 +60,14 @@ class ModelInferenceTests(TestCase):
             cuis_file=None,
             use_model_service=False,
             deid_model_annotation=False,
-            dataset_id=-1,
+            dataset_id=self.dataset.id,
         )
 
         # A document with some text the model can run on
         self.document = Document.objects.create(
             name="Test Doc",
             text="The patient had sever kidney failure.",
-            dataset_id=-1,
+            dataset_id=self.dataset.id,
         )
 
     @contextmanager

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -18,12 +18,12 @@ RAW_MODEL_PATH = os.path.join(
     "mct2_model_pack_train_true.zip"
 )
 MODEL_PATH = os.path.join(
-
+    os.path.dirname(__file__),
+    "..", "..", "media", "fake_model_pack.zip"
 )
 os.symlink(
     RAW_MODEL_PATH,
-    os.path.join(os.path.dirname(__file__),
-    "..", "..", "media", "fake_model_pack.zip")
+    MODEL_PATH
 )
 
 

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -35,6 +35,7 @@ class ModelInferenceTests(TestCase):
         # Minimal project setup
         self.project = ProjectAnnotateEntities.objects.create(
             name="Test Project",
+            model_pack="ABC",
             cuis=None,
             cuis_file=None,
             use_model_service=False,

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -49,7 +49,7 @@ class ModelInferenceTests(TestCase):
         self.project = ProjectAnnotateEntities.objects.create(
             name="Test Project",
             model_pack=self.model_pack,
-            cuis=None,
+            cuis="",
             cuis_file=None,
             use_model_service=False,
             deid_model_annotation=False,

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -89,7 +89,7 @@ class ModelInferenceTests(TestCase):
     def test_can_use_model_for_inference(self):
         with self.use_provided_model():
             response = self.client.post(
-                reverse("api/prepare_documents"),  # adjust to your actual URL name
+                reverse("api/prepare_documents/"),  # adjust to your actual URL name
                 data={
                     "document_ids": [self.document.id],
                     "project_id": self.project.id,

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -1,12 +1,12 @@
 import os
 from contextlib import contextmanager
 from unittest.mock import patch
+import shutil
 
 import pandas as pd
 
 from django.contrib.auth.models import User
 from django.test import TestCase
-from django.urls import reverse
 
 from medcat.cat import CAT
 
@@ -36,14 +36,22 @@ class ModelInferenceTests(TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls._create_symlink()
+        cls._copy_model()
         cls._create_dataset_file()
         # Load once for the whole test class — it's expensive
         cls.cat = CAT.load_model_pack(MODEL_PATH)
 
     @classmethod
-    def _create_symlink(cls):
-        os.symlink(
+    def tearDownClass(cls):
+        os.remove(MODEL_PATH)
+        folder_path = MODEL_PATH.removesuffix(".zip")
+        if os.path.exists(folder_path):
+            shutil.rmtree(folder_path)
+        os.remove(cls.DS_FILE)
+
+    @classmethod
+    def _copy_model(cls):
+        shutil.copyfile(
             RAW_MODEL_PATH,
             MODEL_PATH
         )

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -89,7 +89,7 @@ class ModelInferenceTests(TestCase):
     def test_can_use_model_for_inference(self):
         with self.use_provided_model():
             response = self.client.post(
-                reverse("prepare_documents/"),  # adjust to your actual URL name
+                "/api/prepare-documents/",
                 data={
                     "document_ids": [self.document.id],
                     "project_id": self.project.id,

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -2,13 +2,15 @@ import os
 from contextlib import contextmanager
 from unittest.mock import patch
 
+import pandas as pd
+
 from django.contrib.auth.models import User
 from django.test import TestCase
 from django.urls import reverse
 
 from medcat.cat import CAT
 
-from api.models import ProjectAnnotateEntities, Document, ModelPack, Dataset
+from api.models import ProjectAnnotateEntities, ModelPack, Dataset
 
 
 RAW_MODEL_PATH = os.path.join(
@@ -21,19 +23,29 @@ MODEL_PATH = os.path.join(
     os.path.dirname(__file__),
     "..", "..", "media", "fake_model_pack.zip"
 )
-os.symlink(
-    RAW_MODEL_PATH,
-    MODEL_PATH
-)
 
 
 class ModelInferenceTests(TestCase):
+    DS_FILE = "example_ds.csv"
+    DS_CONTENT = ((-1, "The patient had severe kidney failure"))
 
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls._create_symlink()
         # Load once for the whole test class — it's expensive
         cls.cat = CAT.load_model_pack(MODEL_PATH)
+
+    @classmethod
+    def _create_symlink(cls):
+        os.symlink(
+            RAW_MODEL_PATH,
+            MODEL_PATH
+        )
+
+    @classmethod
+    def _create_dataset_file(cls):
+        df = pd.DataFrame(cls.DS_CONTENT, columns=['id', 'text'])
 
     def setUp(self):
         # A real user — the view reads request.user
@@ -48,7 +60,7 @@ class ModelInferenceTests(TestCase):
         # dataset
         self.dataset = Dataset.objects.create(
             name="fake_dataset",
-            original_file="some_file.csv",
+            original_file=self.DS_FILE,
             description="Fake Dataset"
         )
 
@@ -60,13 +72,6 @@ class ModelInferenceTests(TestCase):
             cuis_file=None,
             use_model_service=False,
             deid_model_annotation=False,
-            dataset_id=self.dataset.id,
-        )
-
-        # A document with some text the model can run on
-        self.document = Document.objects.create(
-            name="Test Doc",
-            text="The patient had sever kidney failure.",
             dataset_id=self.dataset.id,
         )
 
@@ -92,4 +97,4 @@ class ModelInferenceTests(TestCase):
         self.assertEqual(response.data["message"], "Documents prepared successfully")
 
         # The document should now be in prepared_documents
-        self.assertIn(self.document, self.project.prepared_documents.all())
+        self.assertTrye(self.project.prepared_documents.all())

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -11,11 +11,19 @@ from medcat.cat import CAT
 from api.models import ProjectAnnotateEntities, Document, ModelPack
 
 
-MODEL_PATH = os.path.join(
+RAW_MODEL_PATH = os.path.join(
     os.path.dirname(__file__),
-    "..", "..", "..", "..",
-    "../medcat-test-models",
+    "..", "..", "..", "..", "..",
+    "medcat-test-models",
     "mct2_model_pack_train_true.zip"
+)
+MODEL_PATH = os.path.join(
+
+)
+os.symlink(
+    RAW_MODEL_PATH,
+    os.path.join(os.path.dirname(__file__),
+    "..", "..", "media", "fake_model_pack.zip")
 )
 
 

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -30,7 +30,8 @@ MODEL_PATH = os.path.join(
 
 class ModelInferenceTests(TestCase):
     DS_FILE = os.path.join(MEDIA_PATH, "example_ds.csv")
-    DS_CONTENT = ((-1, "The patient had severe kidney failure"),)
+    DS_CONTENT = (("T0", "The patient had severe kidney failure"),)
+    DS_COLUMNS = ("name", "text")
 
     @classmethod
     def setUpClass(cls):
@@ -49,7 +50,7 @@ class ModelInferenceTests(TestCase):
 
     @classmethod
     def _create_dataset_file(cls):
-        df = pd.DataFrame(cls.DS_CONTENT, columns=['id', 'text'])
+        df = pd.DataFrame(cls.DS_CONTENT, columns=cls.DS_COLUMNS)
         df.to_csv(cls.DS_FILE)
 
     def setUp(self):

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -89,7 +89,7 @@ class ModelInferenceTests(TestCase):
     def test_can_use_model_for_inference(self):
         with self.use_provided_model():
             response = self.client.post(
-                reverse("api/prepare_documents/"),  # adjust to your actual URL name
+                reverse("prepare_documents/"),  # adjust to your actual URL name
                 data={
                     "document_ids": [self.document.id],
                     "project_id": self.project.id,

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -30,7 +30,7 @@ MODEL_PATH = os.path.join(
 
 class ModelInferenceTests(TestCase):
     DS_FILE = os.path.join(MEDIA_PATH, "example_ds.csv")
-    DS_CONTENT = ((-1, "The patient had severe kidney failure"))
+    DS_CONTENT = ((-1, "The patient had severe kidney failure"),)
 
     @classmethod
     def setUpClass(cls):

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -115,4 +115,4 @@ class ModelInferenceTests(TestCase):
 
         # The document should now be in prepared_documents
         self.assertTrue(self.project.prepared_documents.all())
-        self.assertEqual(len(self.project.prepared_documents), len(doc_ids))
+        self.assertEqual(len(self.project.prepared_documents.all()), len(doc_ids))

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 from django.contrib.auth.models import User
 from django.test import TestCase
+from rest_framework.test import APIClient
 
 from medcat.cat import CAT
 
@@ -63,8 +64,9 @@ class ModelInferenceTests(TestCase):
 
     def setUp(self):
         # A real user — the view reads request.user
-        self.user = User.objects.create_user(username="testuser", password="password")
-        self.client.force_login(self.user)
+        self.user = User.objects.create_user(username="testuser", password="password", is_staff=True)
+        self.client = APIClient()
+        self.client.force_authenticate(self.user)
 
         self.model_pack = ModelPack.objects.create(
             name='fake-model',
@@ -112,5 +114,5 @@ class ModelInferenceTests(TestCase):
         self.assertEqual(response.data["message"], "Documents prepared successfully")
 
         # The document should now be in prepared_documents
-        self.assertTrye(self.project.prepared_documents.all())
+        self.assertTre(self.project.prepared_documents.all())
         self.assertEqual(len(self.project.prepared_documents), len(doc_ids))

--- a/medcat-trainer/webapp/api/api/tests/test_model_inference.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_inference.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 
 from medcat.cat import CAT
 
-from api.models import ProjectAnnotateEntities, Document
+from api.models import ProjectAnnotateEntities, Document, ModelPack
 
 
 MODEL_PATH = os.path.join(
@@ -32,10 +32,15 @@ class ModelInferenceTests(TestCase):
         self.user = User.objects.create_user(username="testuser", password="password")
         self.client.force_login(self.user)
 
+        self.model_pack = ModelPack.objects.create(
+            name='fake-model',
+            model_pack=MODEL_PATH,
+        )
+
         # Minimal project setup
         self.project = ProjectAnnotateEntities.objects.create(
             name="Test Project",
-            model_pack="ABC",
+            model_pack=self.model_pack,
             cuis=None,
             cuis_file=None,
             use_model_service=False,


### PR DESCRIPTION
This PR adds the test that _should_ be fixed in core lib PR #553 .
However, this is still likely to fail right now since there has been no release of medcat with the change included.