### PR TITLE
build(gliner): Pin ruff version for medcat-gliner to <=0.15.1

### DIFF
--- a/medcat-plugins/medcat-gliner/pyproject.toml
+++ b/medcat-plugins/medcat-gliner/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
-    "ruff",
+    "ruff<=0.15.1",# NOTE: last worked with this version
     "mypy",
 ]
 


### PR DESCRIPTION
Pin ruff version for `medcat-gliner` in optional dependencies so as to avoid failing workflows.

NOTE: 
This is in response to the workflow failing in #556 