### PR TITLE
fix(medcat-trainer): Fix issue with meta-annotation tasks disappearing

### DIFF
--- a/medcat-trainer/webapp/api/api/signals.py
+++ b/medcat-trainer/webapp/api/api/signals.py
@@ -107,6 +107,12 @@ def project_tasks_changed(sender, instance, action, **kwargs):
     # post_remove or post_add actions, overwrite to model_pack supplied MetaCAT tasks.
     if (action.startswith('post') and isinstance(instance, ProjectAnnotateEntitiesFields) and
             instance.model_pack is not None):
+        # NOTE: This part deals with two different sources of information:
+        #       1. sometimes the model pack associated with the project can have meta-cats for meta-annotations
+        #       2. sometimes the project itself defines meta-tasks for the annotator to use
+        #
+        #       Currently the proccess here defaults to useing model-pack defined meta-tasks (if present),
+        #       while allowing for the project-defined ones otherwise.
 
         # Find automated tasks from the model pack
         db_tasks = [

--- a/medcat-trainer/webapp/api/api/signals.py
+++ b/medcat-trainer/webapp/api/api/signals.py
@@ -107,8 +107,25 @@ def project_tasks_changed(sender, instance, action, **kwargs):
     # post_remove or post_add actions, overwrite to model_pack supplied MetaCAT tasks.
     if (action.startswith('post') and isinstance(instance, ProjectAnnotateEntitiesFields) and
             instance.model_pack is not None):
-        instance.tasks.set([MetaTask.objects.filter(prediction_model_id=meta_cat.id).first() for meta_cat in
-                            instance.model_pack.meta_cats.all()])
+
+        # Find automated tasks from the model pack
+        db_tasks = [
+            MetaTask.objects.filter(prediction_model_id=meta_cat.id).first()
+            for meta_cat in instance.model_pack.meta_cats.all()
+        ]
+        # Filter out None values
+        automated_tasks = [t for t in db_tasks if t is not None]
+
+        # Only overwrite if the model pack actually brought automated tasks to the table.
+        # This preserves manual workflows when training from scratch.
+        if automated_tasks:
+            # Disconnect the signal temporarily to prevent infinite recursion loops
+            m2m_changed.disconnect(project_tasks_changed, sender=ProjectAnnotateEntitiesFields.tasks.through)
+            try:
+                instance.tasks.set(automated_tasks)
+            finally:
+                # Always reconnect the signal
+                m2m_changed.connect(project_tasks_changed, sender=ProjectAnnotateEntitiesFields.tasks.through)
 
 
 m2m_changed.connect(project_tasks_changed, sender=ProjectAnnotateEntitiesFields.tasks.through)

--- a/medcat-trainer/webapp/api/api/tests/test_signals.py
+++ b/medcat-trainer/webapp/api/api/tests/test_signals.py
@@ -170,3 +170,44 @@ class ProjectTasksChangedSignalTests(TestCase):
             action='post_add',
         )
         self.assertIn(task, project.tasks.all())
+
+    def test_manual_tasks_persist_when_model_pack_has_no_meta_cats(self):
+        # 1. Create a manual task not tied to any automated prediction model
+        manual_task = MetaTask.objects.create(name='ManualPresenceTask')
+
+        # 2. Build a lightweight ModelPack that does NOT contain any meta_cats
+        cdb = ConceptDB(name='manual-cdb', cdb_file='manual-cdb.dat')
+        cdb.save(skip_load=True)
+        vocab = Vocabulary(name='manual-vocab', vocab_file='manual-vocab.dat')
+        vocab.save(skip_load=True)
+
+        mp = ModelPack(name='base-ner-pack', concept_db=cdb, vocab=vocab)
+        mp.save(skip_load=True)
+
+        # Write a dummy zip file onto the filesystem so model_pack file validation passes
+        pack_path = os.path.join(settings.MEDIA_ROOT, 'manual_base.zip')
+        with open(pack_path, 'wb') as fh:
+            fh.write(b'fake-zip')
+        ModelPack.objects.filter(pk=mp.pk).update(model_pack='manual_base.zip')
+        mp.refresh_from_db()
+
+        # 3. Create a project and attach this empty ModelPack
+        project = create_basic_project(name='manual-tasks-proj')
+        project.model_pack = mp
+        project.concept_db = None
+        project.vocab = None
+        project.save()
+
+        # 4. Add the manual task to the project's many-to-many field
+        project.tasks.add(manual_task)
+
+        # 5. Manually trigger the signal matching a Django admin 'post_add' save operation
+        api_signals.project_tasks_changed(
+            sender=ProjectAnnotateEntitiesFields.tasks.through,
+            instance=project,
+            action='post_add',
+        )
+
+        # 6. Assert that our manual task survived the signal handler execution
+        self.assertIn(manual_task, project.tasks.all())
+        self.assertEqual(project.tasks.count(), 1)


### PR DESCRIPTION
Full details available here:
https://discourse.cogstack.org/t/manual-meta-task-selection-overwritten-when-using-model-pack-without-metacat-models/403

But the TLDR is that in 2.6.1 the `instanceof` fix in #529 (the `signals.py` change, specifically - the branch within it would previously never be reached) made this always trigger the use of tasks from the meta cats in the model pack and never default to the manual ones set for the project.

First commit adds a test, next one adds the relevant fix.