### PR TITLE
build(medcat): Pin stuptools_scm to avoid wider sdist discovery.

### DIFF
--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -133,7 +133,7 @@ test = []  # TODO - list
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=43.0.0", "setuptools_scm>=8", "wheel"]
+requires = ["setuptools>=43.0.0", "setuptools_scm>=8,<10.1.2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
It looks like setuptools_scm==10.1.2 (as opposed to 10.1.1) does a much wider discovery for sdist during project build. This results in the build process attempting to use all sub-projects in the repo for sdist, which causes the build to fail.

I don't fully understand what caused this change or why it was made here (in a patch version). But for now, the simplest solution would be to pin setuptools_scm to where it still worked.

PS:
I do intend to try and find another workaround for this. We don't want to be stuck using an old version of our build system. But I didn't see an obious way to do that without loosing other existing functionality (i.e setting root='.' in setuptools_scm config in pyproject.toml would probably cause that issue).

PPS:
The changelog for 10.1.1..10.1.2 for setuptools_scm is here: https://github.com/pypa/setuptools-scm/compare/setuptools-scm-v10.1.1...setuptools-scm-v10.1.2