### PR TITLE
build(medcat): Fix setuptools and vcs versioning

### DIFF
--- a/.github/workflows/medcat-v2_release.yml
+++ b/.github/workflows/medcat-v2_release.yml
@@ -66,7 +66,7 @@ jobs:
         run: pip install --upgrade build
 
       - name: Build package
-        run: PIP_VERBOSE=2 python -m build
+        run: python -m build -v
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v7

--- a/.github/workflows/medcat-v2_release.yml
+++ b/.github/workflows/medcat-v2_release.yml
@@ -66,7 +66,7 @@ jobs:
         run: pip install --upgrade build
 
       - name: Build package
-        run: python -m build
+        run: PIP_VERBOSE=2 python -m build
 
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v7

--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -133,7 +133,7 @@ test = []  # TODO - list
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=43.0.0", "setuptools_scm>=8,<10.1.2", "vcs_versioning<2.1.0", "wheel"]
+requires = ["setuptools>=43.0.0", "setuptools_scm>=8,<10.1.2", "vcs_versioning<2", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -133,7 +133,7 @@ test = []  # TODO - list
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=43.0.0", "setuptools_scm>=8,<10.1.2", "wheel"]
+requires = ["setuptools>=43.0.0", "setuptools_scm>=8,<10.1.2", "vcs_versioning<2.1.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
This PR _actually_ fixes the issue.
My assumption before was that it was due to `setuptools_scm`, but now it's clear it was actually `vcs_versioning`.

This time I've actually run this locally to make sure it works! (smart move, I know).

And I've added some verbosity to the builds so I can see what's being installed for building (otherwise it was invisible and therefore it wasn't clear which versions were used when things worked or didn't work).