### PR TITLE
fix(medcat-trainer): Fix issue with metrics failing due to missing meta values

### DIFF
--- a/medcat-trainer/webapp/api/api/metrics.py
+++ b/medcat-trainer/webapp/api/api/metrics.py
@@ -339,8 +339,9 @@ class ProjectMetrics(object):
             meta_results = self._eval(meta_model, self.mct_export)
             if 'meta_values' not in meta_results:
                 logger.warning(
-                    "No meta_values found for task %s. Reverting to empty",
-                    meta_model_task)
+                    "No meta_values found for task %s. 'meta_values' no in results, "
+                    "available keys: %s. Reverting to empty results.",
+                    meta_model_task, list(meta_results.keys()))
                 meta_values = {}
             else:
                 meta_values = {v: k for k, v in meta_results['meta_values'].items()}

--- a/medcat-trainer/webapp/api/api/metrics.py
+++ b/medcat-trainer/webapp/api/api/metrics.py
@@ -337,7 +337,13 @@ class ProjectMetrics(object):
                 continue
             meta_model = _meta_models[0]
             meta_results = self._eval(meta_model, self.mct_export)
-            meta_values = {v: k for k, v in meta_results['meta_values'].items()}
+            if 'meta_values' not in meta_results:
+                logger.warning(
+                    "No meta_values found for task %s. Reverting to empty",
+                    meta_model_task)
+                meta_values = {}
+            else:
+                meta_values = {v: k for k, v in meta_results['meta_values'].items()}
             pred_meta_values = []
             counter = 0
             for meta_value in meta_df[meta_model_task]:


### PR DESCRIPTION
There would - after hours of running - be errors such as this:

```
ERROR 2026-06-24 01:05:39,455 process_tasks.py l:26:/home/api/api/metrics.py:303: UserWarning: The meta_model Presence does not exist in this MedCATtrainer export.
  warnings.warn(f"The meta_model {category_name} does not exist in this MedCATtrainer export.", UserWarning)

ERROR 2026-06-24 01:05:39,455 tasks.py l:57:Rescheduling metrics-58-2026-06-23 15:03:19
Traceback (most recent call last):
  File "/home/.venv/lib/python3.12/site-packages/background_task/tasks.py", line 43, in bg_runner
    func(*args, **kwargs)
  File "/home/api/api/metrics.py", line 61, in calculate_metrics
    report = metrics.generate_report(meta_ann=loaded_model_pack)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/api/api/metrics.py", line 429, in generate_report
    anno_df = self.full_annotation_df()
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/api/api/metrics.py", line 340, in full_annotation_df
    meta_values = {v: k for k, v in meta_results['meta_values'].items()}
                                    ~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'meta_values'
WARNING 2026-06-24 01:05:39,618 models.py l:254:Marking task metrics-58-2026-06-23 15:03:19 as failed
```

Which is why metrics seem to fail.

So this PR tries to fix that. So at least things _should_ (hopefully) run to the end.

EDIT:
~~I looked at this in a bit more detail. And while the task had been _scheduled_ for hours by the time this happened, it failed more or less as soon as it ran!
So this may not be the ultimate fix. I'll need to look at this closer.~~
EDIT2: Look at comment below. This should fix the issue, I was fixated on something else.