### PR TITLE
fix(medcat-trainer): Dont use addons in the pipeline for document processing

### DIFF
--- a/medcat-trainer/webapp/api/api/model_cache.py
+++ b/medcat-trainer/webapp/api/api/model_cache.py
@@ -212,11 +212,23 @@ def get_medcat(project,
                cdb_map: Dict[str, CDB]=CDB_MAP,
                vocab_map: Dict[str, Vocab]=VOCAB_MAP,
                cat_map: Dict[str, CAT]=CAT_MAP):
-    """Load (and cache) a MedCAT model for a project.
+    """Load and cache a MedCAT model for a trainer project.
 
-    The full model is always cached. When *addons* is set, only matching addon
-    types (e.g. ``'meta_cat'``, ``'rel_cat'``) are active on the returned CAT.
-    Pass an empty collection for NER+linking only.
+    Args:
+        project: ``ProjectAnnotateEntities`` to load the model for.
+        addons: Addon types to enable on the returned model, e.g.
+            ``['meta_cat']`` or ``['rel_cat']``. Pass an empty collection for
+            NER and linking only. Defaults to ``None`` (all addons enabled).
+        cdb_map: Module-level CDB cache. Defaults to ``CDB_MAP``.
+        vocab_map: Module-level vocab cache. Defaults to ``VOCAB_MAP``.
+        cat_map: Module-level CAT cache. Defaults to ``CAT_MAP``.
+
+    Returns:
+        CAT: A cached MedCAT instance for the project.
+
+    Raises:
+        Exception: If the project ConceptDB, vocab, or model pack is missing
+            or misconfigured.
     """
     cat = get_cached_medcat(project, cat_map)
     if cat is not None:

--- a/medcat-trainer/webapp/api/api/model_cache.py
+++ b/medcat-trainer/webapp/api/api/model_cache.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Collection, Dict, Optional, Any
+from typing import Dict, Optional, Any
 
 from pydantic import ValidationError
 from opentelemetry import trace
@@ -40,16 +40,16 @@ def _remember_full_addons(cat: CAT) -> None:
 
 
 def _apply_addon_filter(cat: CAT,
-                        addons: Optional[Collection[str]] = None) -> CAT:
+                        addons: Optional[list[str]] = None) -> CAT:
     """Return *cat* with pipeline addons filtered; full set is kept on the cache."""
     _remember_full_addons(cat)
     full_addons = getattr(cat, _FULL_ADDONS_ATTR)
     if addons is None:
         cat._pipeline._addons = list(full_addons)
     else:
-        allowed = set(addons)
+        allowed_addons = set(addons)
         cat._pipeline._addons = [
-            addon for addon in full_addons if addon.addon_type in allowed
+            addon for addon in full_addons if addon.addon_type in allowed_addons
         ]
     return cat
 
@@ -208,7 +208,7 @@ def get_medcat_from_model_pack_id(modelpack_id: int, cat_map: Dict[str, CAT]=CAT
 
 @tracer.start_as_current_span("get_medcat")
 def get_medcat(project,
-               addons: Optional[Collection[str]] = None,
+               addons: Optional[list[str]] = None,
                cdb_map: Dict[str, CDB]=CDB_MAP,
                vocab_map: Dict[str, Vocab]=VOCAB_MAP,
                cat_map: Dict[str, CAT]=CAT_MAP):
@@ -217,8 +217,8 @@ def get_medcat(project,
     Args:
         project: ``ProjectAnnotateEntities`` to load the model for.
         addons: Addon types to enable on the returned model, e.g.
-            ``['meta_cat']`` or ``['rel_cat']``. Pass an empty collection for
-            NER and linking only. Defaults to ``None`` (all addons enabled).
+            ``['meta_cat']`` or ``['rel_cat']``. Pass an empty list for NER and
+            linking only. Defaults to ``None`` (all addons enabled).
         cdb_map: Module-level CDB cache. Defaults to ``CDB_MAP``.
         vocab_map: Module-level vocab cache. Defaults to ``VOCAB_MAP``.
         cat_map: Module-level CAT cache. Defaults to ``CAT_MAP``.

--- a/medcat-trainer/webapp/api/api/model_cache.py
+++ b/medcat-trainer/webapp/api/api/model_cache.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Dict, Optional, Any
+from typing import Collection, Dict, Optional, Any
 
 from pydantic import ValidationError
 from opentelemetry import trace
@@ -22,6 +22,8 @@ CDB_MAP = {}
 VOCAB_MAP = {}
 CAT_MAP = {}
 
+_FULL_ADDONS_ATTR = '_trainer_full_addons'
+
 logger = logging.getLogger(__name__)
 tracer = trace.get_tracer("medcat-trainer")
 
@@ -30,6 +32,26 @@ try:
 except ValueError:
     _MAX_MODELS_LOADED = 1
     logger.warning("MAX_MEDCAT_MODELS is not an integer, using default value of 1")
+
+
+def _remember_full_addons(cat: CAT) -> None:
+    if not hasattr(cat, _FULL_ADDONS_ATTR):
+        setattr(cat, _FULL_ADDONS_ATTR, list(cat._pipeline._addons))
+
+
+def _apply_addon_filter(cat: CAT,
+                        addons: Optional[Collection[str]] = None) -> CAT:
+    """Return *cat* with pipeline addons filtered; full set is kept on the cache."""
+    _remember_full_addons(cat)
+    full_addons = getattr(cat, _FULL_ADDONS_ATTR)
+    if addons is None:
+        cat._pipeline._addons = list(full_addons)
+    else:
+        allowed = set(addons)
+        cat._pipeline._addons = [
+            addon for addon in full_addons if addon.addon_type in allowed
+        ]
+    return cat
 
 
 def _clear_models(cdb_map: Dict[str, CDB]=CDB_MAP,
@@ -186,19 +208,26 @@ def get_medcat_from_model_pack_id(modelpack_id: int, cat_map: Dict[str, CAT]=CAT
 
 @tracer.start_as_current_span("get_medcat")
 def get_medcat(project,
+               addons: Optional[Collection[str]] = None,
                cdb_map: Dict[str, CDB]=CDB_MAP,
                vocab_map: Dict[str, Vocab]=VOCAB_MAP,
                cat_map: Dict[str, CAT]=CAT_MAP):
+    """Load (and cache) a MedCAT model for a project.
+
+    The full model is always cached. When *addons* is set, only matching addon
+    types (e.g. ``'meta_cat'``, ``'rel_cat'``) are active on the returned CAT.
+    Pass an empty collection for NER+linking only.
+    """
     cat = get_cached_medcat(project, cat_map)
     if cat is not None:
         trace.get_current_span().add_event("Loaded medcat from cache")
-        return cat
+        return _apply_addon_filter(cat, addons)
     try:
         if project.model_pack is None:
             cat = get_medcat_from_cdb_vocab(project, cdb_map, vocab_map, cat_map)
         else:
             cat = get_medcat_from_model_pack(project, cat_map)
-        return cat
+        return _apply_addon_filter(cat, addons)
     except AttributeError as err:
         raise Exception('Failure loading Project ConceptDB, Vocab or Model Pack. Are these set correctly?') from err
 

--- a/medcat-trainer/webapp/api/api/utils.py
+++ b/medcat-trainer/webapp/api/api/utils.py
@@ -454,7 +454,7 @@ def prep_docs(project_id: List[int], doc_ids: List[int], user_id: int):
     else:
         # Use local medcat model
         logger.info('Loading CAT object in bg process for project: %s', project.id)
-        cat = get_medcat(project=project)
+        cat = get_medcat(project=project, addons=[])
 
         # Set CAT filters
         cat.config.components.linking.filters.cuis = cuis

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from smtplib import SMTPException
@@ -44,7 +45,6 @@ print(os.environ)
 """
 
 logger = logging.getLogger(__name__)
-
 
 # Get the basic version of MedCAT
 cat = None
@@ -329,7 +329,7 @@ def prepare_documents(request):
                                         existing_annotations=anns)
                     else:
                         # Use local medcat model
-                        cat = get_medcat(project=project)
+                        cat = get_medcat(project=project, addons=[])
                         logger.info('loaded medcat model for project: %s', project.id)
 
                         # Set CAT filters

--- a/medcat-trainer/webapp/api/api/views.py
+++ b/medcat-trainer/webapp/api/api/views.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import os
 from smtplib import SMTPException


### PR DESCRIPTION
MedCAT Addons are not needed when calling prepare-documents API

This fixes this error, along with any other issue found inside an addon that isn't used

```
INFO 2026-06-24 10:21:43,721 pipeline.py l:329:Running component ner:cat_ner for 16730 of text (94412370605648)
INFO 2026-06-24 10:21:43,738 cdb.py l:45:Resetting subnames
INFO 2026-06-24 10:21:47,591 pipeline.py l:329:Running component linking:medcat2_linker for 16730 of text (94412370605648)
Token indices sequence length is longer than the specified maximum sequence length for this model (4925 > 512). Running this sequence through the model will result in indexing errors
ERROR 2026-06-24 10:21:48,080 rel_dataset.py l:348:document id : 0 failed to process relation
Traceback (most recent call last):
  File "/home/.venv/lib/python3.12/site-packages/medcat/components/addons/relation_extraction/rel_dataset.py", line 343, in _create_relation_validation
    assert ent1_token_start_pos
```

This is definitely messy as it mutates the cached CAT, but seems like this is done other places anyway like cat.config.components.linking.filters.cuis = cuis