### PR TITLE
build(medcat): Add support to latest build systems.

### DIFF
--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -133,7 +133,7 @@ test = []  # TODO - list
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=43.0.0", "setuptools_scm>=8,<10.1.2", "vcs_versioning<2", "wheel"]
+requires = ["setuptools>=43.0.0", "setuptools_scm>=8,!=10.1.2", "vcs_versioning!=2.0.*,!=2.1.*", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/medcat-v2/pyproject.toml
+++ b/medcat-v2/pyproject.toml
@@ -133,7 +133,7 @@ test = []  # TODO - list
 [build-system]
 # These are the assumed default build requirements from pip:
 # https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support
-requires = ["setuptools>=43.0.0", "setuptools_scm>=8,!=10.1.2", "vcs_versioning!=2.0.*,!=2.1.*", "wheel"]
+requires = ["setuptools>=43.0.0", "setuptools_scm>10.1.2", "vcs_versioning>=2.2.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
There's been a release of setuptools_scm (10.2.0) that fixed the underlying issue. Unfortunately there was no mention of the issue in the [release notes](https://github.com/pypa/setuptools-scm/releases/tag/setuptools-scm-v10.2.0). However, the [fix PR](https://github.com/pypa/setuptools-scm/pull/1441) commit (5b640c6) is within the [compare](https://github.com/pypa/setuptools-scm/compare/setuptools-scm-v10.1.2...setuptools-scm-v10.2.0) so I am fairly certain the fix is in place.

But just to make sure, I ran the build locally as well and verified the build was successful and that no parent folders were being moved (which was the case previously).

So all in all, what this PR does is fix the offending packages ( and ) to not include the versions within which they broke the builds.