### PR TITLE
fix(medcat-trainer): Fix Offline  container usage by setting env vars

### DIFF
--- a/medcat-trainer/webapp/Dockerfile
+++ b/medcat-trainer/webapp/Dockerfile
@@ -61,6 +61,9 @@ COPY scripts ./scripts
 COPY templates ./templates
 COPY --from=frontend-builder /build/dist ./frontend/dist
 
+ENV UV_PROJECT=/home \
+    UV_NO_SYNC=1
+
 # MEDIA_ROOT is a runtime volume; ensure the directory exists without baking in local uploads
 RUN mkdir -p /home/api/media
 


### PR DESCRIPTION

Trying to start up trainer without internet access doesnt work, due to the use of `uv run` seeming to try to sync every dependency on startup.

The fix sets these env vars in the docker image.

Excitingly, the issue is never seen if you've started it before with internet access, as the volumes get mounted and uv caches everything. To recreate this one you need to do an air gapped install (pull the image, disable internet, then run the image)

Issue didn't exist before when we had the older dockerfile setup, as the /uv/cache or whatever directory got kept in the image, but the multilayerone doesnt have that anymore

```
$ k logs cogstack-medcat-trainer-9c477594b-h4h4r  -f
Defaulted container "medcat-trainer" out of: medcat-trainer, nginx
2026-06-29 10:13:15,413 INFO Set uid to user 0 succeeded
2026-06-29 10:13:15,415 INFO supervisord started with pid 1
2026-06-29 10:13:16,421 INFO spawned: 'bg-process' with pid 7
2026-06-29 10:13:16,429 INFO spawned: 'db-backup' with pid 8
2026-06-29 10:13:16,434 INFO spawned: 'medcattrainer' with pid 11
[medcattrainer] Starting medcat trainer
[medcattrainer] Skipping db backup script as the db type is not  set to 'sqlite3'. The DB_ENGINE env var is set to 'postgresql' 
2026-06-29 10:13:17,445 INFO success: bg-process entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-06-29 10:13:17,445 INFO success: db-backup entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
2026-06-29 10:13:17,445 INFO success: medcattrainer entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
[bg-process] error: Request failed after 3 retries in 4.1s
[bg-process]   Caused by: Failed to fetch: `https://pypi.org/simple/opentelemetry-api/`
[bg-process]   Caused by: error sending request for url (https://pypi.org/simple/opentelemetry-api/)
[bg-process]   Caused by: client error (Connect)
[bg-process]   Caused by: dns error
[bg-process]   Caused by: failed to lookup address information: Name or service not known
[medcattrainer] error: Request failed after 3 retries in 5.7s
[medcattrainer]   Caused by: Failed to fetch: `https://pypi.org/simple/opentelemetry-instrumentation-threading/`
[medcattrainer]   Caused by: error sending request for url (https://pypi.org/simple/opentelemetry-instrumentation-threading/)
[medcattrainer]   Caused by: client error (Connect)
[medcattrainer]   Caused by: dns error
[medcattrainer]   Caused by: failed to lookup address information: Name or service not known
[bg-process] error: Request failed after 3 retries in 3.9s
[bg-process]   Caused by: Failed to fetch: `https://pypi.org/simple/opentelemetry-resource-detector-containerid/`
[bg-process]   Caused by: error sending request for url (https://pypi.org/simple/opentelemetry-resource-detector-containerid/)
[bg-process]   Caused by: client error (Connect)
[bg-process]   Caused by: dns error
[bg-process]   Caused by: failed to lookup address information: Name or service not known
[medcattrainer] error: Request failed after 3 retries in 3.9s
[medcattrainer]   Caused by: Failed to fetch: `https://pypi.org/simple/django-filter/`
[medcattrainer]   Caused by: error sending request for url (https://pypi.org/simple/django-filter/)
[medcattrainer]   Caused by: client error (Connect)
[medcattrainer]   Caused by: dns error
[medcattrainer]   Caused by: failed to lookup address information: Name or service not known
[bg-process] error: Request failed after 3 retries in 4.2s
[bg-process]   Caused by: Failed to fetch: `https://pypi.org/simple/requests/`
[bg-process]   Caused by: error sending request for url (https://pypi.org/simple/requests/)
[bg-process]   Caused by: client error (Connect)
[bg-process]   Caused by: dns error
[bg-process]   Caused by: failed to lookup address information: Name or service not known
[medcattrainer] error: Request failed after 3 retries in 4.4s
```