### PR TITLE
feat(medcat-trainer): Speed up project upload

### DIFF
--- a/medcat-trainer/webapp/api/api/models.py
+++ b/medcat-trainer/webapp/api/api/models.py
@@ -354,7 +354,7 @@ class Relation(models.Model):
         return str(self.label)
 
 
-def update_project_last_modified(project: ProjectAnnotateEntities, last_modified):
+def update_project_last_modified(project: 'ProjectAnnotateEntities', last_modified):
     # so that the local project last_modified is updated
     project.last_modified = last_modified
     # so that the project last_modified is updated in the database

--- a/medcat-trainer/webapp/api/api/models.py
+++ b/medcat-trainer/webapp/api/api/models.py
@@ -354,6 +354,14 @@ class Relation(models.Model):
         return str(self.label)
 
 
+def update_project_last_modified(project: ProjectAnnotateEntities, last_modified):
+    # so that the local project last_modified is updated
+    project.last_modified = last_modified
+    # so that the project last_modified is updated in the database
+    ProjectAnnotateEntities.objects.filter(pk=project.id).update(
+        last_modified=last_modified
+    )
+
 class EntityRelation(models.Model):
     user = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
     project = models.ForeignKey('Project', on_delete=models.CASCADE)
@@ -370,12 +378,7 @@ class EntityRelation(models.Model):
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
-        # so that the local project last_modified is updated
-        self.project.last_modified = self.last_modified
-        # so that the project last_modified is updated in the database
-        ProjectAnnotateEntities.objects.filter(pk=self.project_id).update(
-            last_modified=self.last_modified
-        )
+        update_project_last_modified(self.project, self.last_modified)
 
     def __str__(self):
         return f'{self.start_entity} - {self.relation} - {self.end_entity}'
@@ -406,8 +409,7 @@ class AnnotatedEntity(models.Model):
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
-        self.project.last_modified = self.last_modified
-        self.project.save()
+        update_project_last_modified(self.project, self.last_modified)
 
     def __str__(self):
         return str(self.entity)
@@ -555,8 +557,7 @@ class MetaAnnotation(models.Model):
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
-        self.annotated_entity.last_modified = self.last_modified
-        self.annotated_entity.save()
+        update_project_last_modified(self.annotated_entity.project, self.last_modified)
 
     def __str__(self):
         return str(self.annotated_entity)

--- a/medcat-trainer/webapp/api/api/models.py
+++ b/medcat-trainer/webapp/api/api/models.py
@@ -370,8 +370,12 @@ class EntityRelation(models.Model):
 
     def save(self, *args, **kwargs):
         super().save(*args, **kwargs)
+        # so that the local project last_modified is updated
         self.project.last_modified = self.last_modified
-        self.project.save()
+        # so that the project last_modified is updated in the database
+        ProjectAnnotateEntities.objects.filter(pk=self.project_id).update(
+            last_modified=self.last_modified
+        )
 
     def __str__(self):
         return f'{self.start_entity} - {self.relation} - {self.end_entity}'

--- a/medcat-trainer/webapp/api/api/utils.py
+++ b/medcat-trainer/webapp/api/api/utils.py
@@ -485,12 +485,12 @@ def prep_docs(project_id: List[int], doc_ids: List[int], user_id: int):
 @receiver(post_save, sender=ProjectAnnotateEntities)
 def save_project_anno(sender, instance, **kwargs):
     if instance.cuis_file:
-        post_save.disconnect(save_project_anno, sender=ProjectAnnotateEntities)
         cuis_from_file = json.load(open(instance.cuis_file.path))
         cui_list = [c.strip() for c in instance.cuis.split(',')]
-        instance.cuis = ','.join(set(cui_list) - set(cuis_from_file))
-        instance.save()
-        post_save.connect(save_project_anno, sender=ProjectAnnotateEntities)
+        new_cuis = ','.join(set(cui_list) - set(cuis_from_file))
+        if new_cuis != instance.cuis:
+            instance.cuis = new_cuis
+            ProjectAnnotateEntities.objects.filter(pk=instance.pk).update(cuis=new_cuis)
 
 
 def env_str_to_bool(var: str, default: bool):

--- a/medcat-trainer/webapp/api/api/utils.py
+++ b/medcat-trainer/webapp/api/api/utils.py
@@ -3,6 +3,7 @@ import logging
 import os
 from typing import List
 import dill
+from functools import lru_cache
 
 import requests
 from background_task import background
@@ -482,10 +483,16 @@ def prep_docs(project_id: List[int], doc_ids: List[int], user_id: int):
                 project.id, project.prepared_documents)
 
 
+@lru_cache(maxsize=8)
+def _load_cuis_from_file(path):
+    with open(path) as f:
+        return json.load(f)
+
+
 @receiver(post_save, sender=ProjectAnnotateEntities)
 def save_project_anno(sender, instance, **kwargs):
     if instance.cuis_file:
-        cuis_from_file = json.load(open(instance.cuis_file.path))
+        cuis_from_file = _load_cuis_from_file(instance.cuis_file.path)
         cui_list = [c.strip() for c in instance.cuis.split(',')]
         new_cuis = ','.join(set(cui_list) - set(cuis_from_file))
         if new_cuis != instance.cuis:


### PR DESCRIPTION
This PR attempts to speed up project upload.

I was having trouble uploading the entity linking challenge project (i.e conversion from the raw linking challenge) to the app.cogstack.org trainer. It seemed to just crash it.
However, when I tried on the demo trainer (sites.er.kcl.ac.uk), it worked just fine.

So I thought perhaps the app.cogstack.org is timing out.

Looking at the timings, it looked like it was taking around 5m30s to upload the dataset to the the trainer instance I was running locally.
I got the time down to around half.
More specifically, it took 328.675s before, and with the changes it took 150.610s.

Here's the changes:
- Avoid resaving the ProjectAnnotateEntities twice
  - The signal caused every save to happen twice for the entire DB entry
- Avoid some file system IO by caching CUI filter file
  - This was also loaded off disk at every save time
- Use model update instead of save for modifcation date of project annotate entities
  - The idea being that instead of updating all fields, only the relevant field gets updated

EDIT:
The next step would be to run this as a background task. But then some of the UI would need to also reflect that. So didn't get a chance to do that yet.