### PR TITLE
build(medcat-v1-tutorials): Fix build issue due to new pytest

### DIFF
--- a/v1/medcat-tutorials/requirements-dev.txt
+++ b/v1/medcat-tutorials/requirements-dev.txt
@@ -1,6 +1,7 @@
 medcat~=1.16.0
 pandas<2.0.0
 seaborn~=0.11.2
+pytest<9.1.0
 pytest-xdist~=2.5.0
 nbmake<1.5
 nbconvert<6


### PR DESCRIPTION
Turns out latest pytest (9.1.0 and later) removes some deprecated methods, but some bits running in this old workflow seem to require these (nbmake, specifically, it looks like) and fail with the newer releases (since June 14th).

So this PR avoids the newer versions. Not ideal, but for the legacy version, I'm alright with it.

<details>
<summary>Failure reference</summary>
https://github.com/CogStack/cogstack-nlp/actions/runs/29176877453/job/86607502623

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/Python/3.11.15/x64/bin/pytest", line 6, in <module>
    sys.exit(_console_main())
             ^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 253, in _console_main
    code = _main(prog=_get_prog_name(sys.argv))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 223, in _main
    config = _prepareconfig(new_args, plugins, prog=prog)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 410, in _prepareconfig
    config: Config = pluginmanager.hook.pytest_cmdline_parse(
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_hooks.py", line 512, in __call__
    return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_manager.py", line 120, in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_callers.py", line 167, in _multicall
    raise exception
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_callers.py", line 139, in _multicall
    teardown.throw(exception)
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/helpconfig.py", line 124, in pytest_cmdline_parse
    config = yield
             ^^^^^
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_callers.py", line 121, in _multicall
    res = hook_impl.function(*args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1232, in pytest_cmdline_parse
    self.parse(args)
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 1583, in parse
    self.pluginmanager.load_setuptools_entrypoints("pytest11")
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_manager.py", line 417, in load_setuptools_entrypoints
    self.register(plugin, name=ep.name)
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/_pytest/config/__init__.py", line 571, in register
    plugin_name = super().register(plugin, name)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_manager.py", line 168, in register
    self._verify_hook(hook, hookimpl)
  File "/opt/hostedtoolcache/Python/3.11.15/x64/lib/python3.11/site-packages/pluggy/_manager.py", line 343, in _verify_hook
    raise PluginValidationError(
pluggy._manager.PluginValidationError: Plugin 'nbmake' for hook 'pytest_collect_file'
hookimpl definition: pytest_collect_file(path: str, parent: Any) -> Optional[Any]
Argument(s) {'path'} are declared in the hookimpl but can not be found in the hookspec
Error: Process completed with exit code 1.
```
</details>