### PR TITLE
fix(medcat-trainer): login success being emitted even on fail breaks login

### DIFF
--- a/medcat-trainer/webapp/frontend/src/components/common/Login.vue
+++ b/medcat-trainer/webapp/frontend/src/components/common/Login.vue
@@ -102,12 +102,9 @@ export default {
   },
   created () {
     window.addEventListener('keyup', this.keyup)
-    this.$nextTick(function () {
-      document.getElementById('uname').focus()
+    this.$nextTick(() => {
+      document.getElementById('uname')?.focus()
     })
-  },
-  mounted () {
-    EventBus.$emit('login:success')
   },
 }
 </script>

--- a/medcat-trainer/webapp/frontend/src/tests/components/Login.spec.ts
+++ b/medcat-trainer/webapp/frontend/src/tests/components/Login.spec.ts
@@ -61,6 +61,17 @@ describe('Login.vue', () => {
     expect(wrapper.text()).toContain('Login')
     expect(wrapper.find('#uname').exists()).toBe(true)
     expect(wrapper.find('#password').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('does not emit login:success on mount', async () => {
+    const emitSpy = vi.spyOn(EventBus, '$emit')
+    const wrapper = mountLogin()
+    await flushPromises()
+
+    expect(emitSpy).not.toHaveBeenCalledWith('login:success')
+    emitSpy.mockRestore()
+    wrapper.unmount()
   })
 
   it('posts credentials and sets cookies on successful login', async () => {


### PR DESCRIPTION

## Issue

Trainer is failing to login as admin, and then when you click login it doesnt do anything but show a console error

```
Uncaught (in promise) TypeError: can't access property "focus", document.getElementById(...) is null
    created http://localhost:8001/static/index-79q67wWY.js:584
    promise callback*zs http://localhost:8001/static/vue-vendor-DdKzZALK.js:13
    created http://localhost:8001/static/index-79q67wWY.js:584
    as http://localhost:8001/static/vue-vendor-DdKzZALK.js:13
    yt http://localhost:8001/static/vue-vendor-DdKzZALK.js:13
    wl http://localhost:8001/static/vue-vendor-DdKzZALK.js:15
```

<img width="923" height="579" alt="image" src="https://github.com/user-attachments/assets/16db844c-7395-4327-bcf8-f16da5815b87" />

## Issue

Some race condition, restart issue, or token expiry bug is happening here. Users encounter the bug after complete VM restart (where browser is on the same VM accessing localhost)

I can reproduce by manually deleting the cookies 

- Open trainer, login as admin, see the cog
- Edit cookies, and delete "admin = True"
- Assert the cog has dissappeared
- now click login, and see it fail with the above error

## Fix
Two fixes. The first one at least solves the console bug, null checking the element before clicking.

But I think this is the main fix for why it might have been needed (assuming users aren't deleting cookies themselves:

```
-  mounted () {
-    EventBus.$emit('login:success')
-  },
- ```





