### PR TITLE
ci(medcat-service): Only make new service docker image when files changed

### DIFF
--- a/.github/workflows/medcat-service_docker.yml
+++ b/.github/workflows/medcat-service_docker.yml
@@ -4,7 +4,11 @@ on:
   push:
     branches: [ main ]
     tags:
-      - 'medcat-service/v*.*.*'  # e.g., medcat-serice/v0.1.1
+      - 'medcat-service/v*.*.*'  # e.g., medcat-service/v0.1.1
+    paths:
+      - 'medcat-v2/**'
+      - 'medcat-service/**'
+      - '.github/workflows/medcat-service**'
   pull_request:
     paths:
       - 'medcat-v2/**'


### PR DESCRIPTION
I'm not 100% on if I want to do this...

But the aim is to only publish a new `:latest` into dockerhub when something has actually changed. To reduce the churn with the auto deployment. Will also apply to medcat-trainer if so. 

One alternative is on the other project I can stop the git commit every time there's a new digest. 

