### PR TITLE
fix(medcat-trainer): Secret_key env var is now used instead of defaulting

### DIFF
--- a/medcat-trainer/docs/installation.md
+++ b/medcat-trainer/docs/installation.md
@@ -130,6 +130,8 @@ Host-level Compose variables (for example port overrides) can be set by copying
 | `MCTRAINER_BOOTSTRAP_ADMIN_USERNAME` | Bootstrap admin username (default `admin`). |
 | `MCTRAINER_BOOTSTRAP_ADMIN_EMAIL` | Bootstrap admin email. |
 | `MCTRAINER_BOOTSTRAP_ADMIN_PASSWORD` | Bootstrap admin password (change in real deployments). |
+| `ENV` | Deployment realm: `non-prod` (default) or `prod`. Controls DEBUG and SECRET_KEY env vars |
+| `SECRET_KEY` | Django signing key to set for production deployments. Required when `ENV=prod`. |
 
 ### SMTP (optional, for password reset emails)
 

--- a/medcat-trainer/webapp/api/api/tests/test_settings.py
+++ b/medcat-trainer/webapp/api/api/tests/test_settings.py
@@ -1,0 +1,32 @@
+"""Unit tests for Django SECRET_KEY resolution."""
+
+from unittest import TestCase
+
+from core.settings import NON_PROD_DEFAULT_SECRET_KEY, resolve_secret_key
+
+
+class ResolveSecretKeyTests(TestCase):
+    """SECRET_KEY must come from the environment when set, not the hardcoded default."""
+
+    def test_prod_uses_provided_secret_key(self):
+        self.assertEqual(
+            resolve_secret_key('prod', 'env-provided-secret'),
+            'env-provided-secret',
+        )
+
+    def test_prod_without_secret_key_exits(self):
+        with self.assertRaises(SystemExit) as ctx:
+            resolve_secret_key('prod', None)
+        self.assertIn('No SECRET_KEY environment variable found', str(ctx.exception))
+
+    def test_non_prod_defaults_when_secret_key_missing(self):
+        self.assertEqual(
+            resolve_secret_key('non-prod', None),
+            NON_PROD_DEFAULT_SECRET_KEY,
+        )
+
+    def test_non_prod_uses_provided_secret_key(self):
+        self.assertEqual(
+            resolve_secret_key('non-prod', 'non-prod-env-secret'),
+            'non-prod-env-secret',
+        )

--- a/medcat-trainer/webapp/api/core/settings.py
+++ b/medcat-trainer/webapp/api/core/settings.py
@@ -28,15 +28,27 @@ CSRF_TRUSTED_ORIGINS = ['http://127.0.0.1:8001', 'http://localhost:8001'] + trus
 SECURE_CROSS_ORIGIN_OPENER_POLICY = None
 
 # SECURITY WARNING: keep the secret key used in production secret!
-realm = os.environ.get('ENV', 'non-prod')
-secret_key = os.environ.get('SECRET_KEY')
-if realm == 'prod' and secret_key is None:
-    msg = 'No SECRET_KEY environment variable found for prod environment. Please add a secret key and re-run'
-    log.error(msg)
-    sys.exit(msg)
-else:
+NON_PROD_DEFAULT_SECRET_KEY = 'q$&esydgbn2=#-k5s5i(+^dtxs1@$50_(ln0wuw@zig4m&^m7='
+
+
+def resolve_secret_key(realm, secret_key):
+    """Resolve Django SECRET_KEY from ENV realm and SECRET_KEY env values.
+
+    Prod requires an explicit secret. Non-prod may fall back to a default.
+    When a secret is provided via the environment, it is always preferred.
+    """
+    if secret_key:
+        return secret_key
+    if realm == 'prod':
+        msg = 'No SECRET_KEY environment variable found for prod environment. Please add a secret key and re-run'
+        log.error(msg)
+        sys.exit(msg)
     log.info('Running non-prod environment, defaulting django SECRET_KEY')
-    SECRET_KEY = 'q$&esydgbn2=#-k5s5i(+^dtxs1@$50_(ln0wuw@zig4m&^m7='
+    return NON_PROD_DEFAULT_SECRET_KEY
+
+
+realm = os.environ.get('ENV', 'non-prod')
+SECRET_KEY = resolve_secret_key(realm, os.environ.get('SECRET_KEY'))
 
 # SECURITY WARNING: don't run with debug turned on in production!
 try:


### PR DESCRIPTION

## Behavior before

If I set env to PROD, and provide a SECRET_KEY env var, it was never used, django still loaded the hardcoded one

## Behavior after
If I provide a SECRET_KEY env var, it is now used (no matter the environment)