### PR TITLE
ci(medcat-trainer): Fix failing coverage upload with matrix build

### DIFF
--- a/.github/workflows/medcat-trainer_ci.yml
+++ b/.github/workflows/medcat-trainer_ci.yml
@@ -228,7 +228,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: backend-coverage
+          name: backend-coverage-${{ matrix.medcat-source }}
           path: |
             medcat-trainer/webapp/api/coverage.xml
             medcat-trainer/webapp/api/htmlcov


### PR DESCRIPTION

I think when both matrix builds happen to finish at the same time, it always fails to create the artifact


Fixes the build in another PR https://github.com/CogStack/cogstack-nlp/pull/579

https://github.com/CogStack/cogstack-nlp/actions/runs/29413683673/job/87346482524
```
Run actions/upload-artifact@v7
  with:
    name: backend-coverage
    path: medcat-trainer/webapp/api/coverage.xml
  medcat-trainer/webapp/api/htmlcov
  
    if-no-files-found: ignore
    compression-level: 6
    overwrite: false
    include-hidden-files: false
    archive: true
  env:
    UV_PYTHON_INSTALL_DIR: /home/runner/work/_temp/uv-python-dir
    UV_PYTHON: 3.12
    UV_CACHE_DIR: /home/runner/work/_temp/setup-uv-cache
Multiple search paths detected. Calculating the least common ancestor of all paths
The least common ancestor is /home/runner/work/cogstack-nlp/cogstack-nlp/medcat-trainer/webapp/api. This will be the root directory of the artifact
With the provided path, there will be 33 files uploaded
Artifact name is valid!
Root directory input is valid!
Error: Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run

```