### PR TITLE
fix(medcat-trainer): Avoid creating duplicate MetaCAT models upon model upload

### DIFF
--- a/medcat-trainer/webapp/api/api/models.py
+++ b/medcat-trainer/webapp/api/api/models.py
@@ -122,8 +122,11 @@ class ModelPack(models.Model):
             for meta_cat_dir, meta_cat_cnf in meta_cat_addons:
                 meta_model_name = f'{meta_cat_cnf.general.category_name} - {meta_cat_cnf.model.model_name}'
                 if MetaCATModel.objects.filter(name=meta_model_name).exists():
-                    logger.info("Meta CAT Model '%s' already exists, avoiding duplicate registration", meta_model_name)
-                    continue
+                    prev_meta_can_name = meta_model_name
+                    meta_model_name = f'{meta_model_name} - from {self.id}'
+                    logger.info(
+                        "Meta CAT Model '%s' already exists, avoiding duplicate registration, renaming to %s",
+                        prev_meta_can_name, meta_model_name)
                 mc_model = MetaCATModel()
                 mc_model.meta_cat_dir = meta_cat_dir.replace(f'{MEDIA_ROOT}/', '')
                 mc_model.name = meta_model_name

--- a/medcat-trainer/webapp/api/api/models.py
+++ b/medcat-trainer/webapp/api/api/models.py
@@ -121,12 +121,7 @@ class ModelPack(models.Model):
             metaCATmodels = []
             for meta_cat_dir, meta_cat_cnf in meta_cat_addons:
                 meta_model_name = f'{meta_cat_cnf.general.category_name} - {meta_cat_cnf.model.model_name}'
-                if MetaCATModel.objects.filter(name=meta_model_name).exists():
-                    prev_meta_can_name = meta_model_name
-                    meta_model_name = f'{meta_model_name} - from {self.id}'
-                    logger.info(
-                        "Meta CAT Model '%s' already exists, avoiding duplicate registration, renaming to %s",
-                        prev_meta_can_name, meta_model_name)
+                meta_model_name = f'{meta_model_name} - from {self.id}'
                 mc_model = MetaCATModel()
                 mc_model.meta_cat_dir = meta_cat_dir.replace(f'{MEDIA_ROOT}/', '')
                 mc_model.name = meta_model_name

--- a/medcat-trainer/webapp/api/api/models.py
+++ b/medcat-trainer/webapp/api/api/models.py
@@ -120,9 +120,13 @@ class ModelPack(models.Model):
             meta_cat_addons = load_meta_cat_info_from_model_folder(unpacked_model_pack_path)
             metaCATmodels = []
             for meta_cat_dir, meta_cat_cnf in meta_cat_addons:
+                meta_model_name = f'{meta_cat_cnf.general.category_name} - {meta_cat_cnf.model.model_name}'
+                if MetaCATModel.objects.filter(name=meta_model_name).exists():
+                    logger.info("Meta CAT Model '%s' already exists, avoiding duplicate registration", meta_model_name)
+                    continue
                 mc_model = MetaCATModel()
                 mc_model.meta_cat_dir = meta_cat_dir.replace(f'{MEDIA_ROOT}/', '')
-                mc_model.name = f'{meta_cat_cnf.general.category_name} - {meta_cat_cnf.model.model_name}'
+                mc_model.name = meta_model_name
                 mc_model.save(unpack_load_meta_cat_dir=False)
                 mc_model.get_or_create_meta_tasks_and_values(meta_cat_cnf)
                 metaCATmodels.append(mc_model)

--- a/medcat-trainer/webapp/api/api/tests/test_model_pack_addons.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_pack_addons.py
@@ -128,7 +128,7 @@ class ModelPackAddonRegistrationTests(TestCase):
         self.assertEqual(model_pack.meta_cats.count(), 0)
 
 
-    def test_re_register_model_pack_with_same_meta_cat_does_not_create_duplicate(self):
+    def test_re_register_model_pack_with_same_meta_cat_reregisters_with_new_name(self):
         model_pack, _ = self._prepare_model_pack(name="dupe-addon-pack")
         addon_cnfs = [
             _make_meta_cat_addon_cnf(),
@@ -142,4 +142,4 @@ class ModelPackAddonRegistrationTests(TestCase):
         with self._register_model_pack(model_pack2, addon_cnfs):
             pass
         registered_meta_cats = MetaCATModel.objects.all()
-        self.assertEqual(len(registered_meta_cats), len(addon_cnfs))
+        self.assertEqual(len(registered_meta_cats), 2 * len(addon_cnfs))

--- a/medcat-trainer/webapp/api/api/tests/test_model_pack_addons.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_pack_addons.py
@@ -71,7 +71,7 @@ class ModelPackAddonRegistrationTests(TestCase):
         self.assertIsNotNone(model_pack.vocab)
         self.assertEqual(model_pack.meta_cats.count(), 1)
         meta_cat_model = model_pack.meta_cats.get()
-        self.assertEqual(meta_cat_model.name, "Status - bert")
+        self.assertEqual(meta_cat_model.name, "Status - bert - 1")
         self.assertTrue(meta_cat_model.meta_cat_dir.endswith("addon_meta_cat.Status"))
 
     def test_register_model_pack_with_rel_cat_only(self):
@@ -98,7 +98,7 @@ class ModelPackAddonRegistrationTests(TestCase):
         self.assertEqual(model_pack.meta_cats.count(), 2)
         self.assertEqual(
             set(model_pack.meta_cats.values_list("name", flat=True)),
-            {"Status - bert", "Experiencer - roberta"},
+            {"Status - bert - 1", "Experiencer - roberta - 1"},
         )
 
     def test_register_model_pack_with_meta_cat_and_rel_cat(self):
@@ -113,7 +113,7 @@ class ModelPackAddonRegistrationTests(TestCase):
         # All addons load; only MetaCAT rows are registered.
         self.assertEqual(model_pack.meta_cats.count(), 1)
         meta_cat_model = model_pack.meta_cats.get()
-        self.assertEqual(meta_cat_model.name, "Status - bert")
+        self.assertEqual(meta_cat_model.name, "Status - bert - from 1")
         self.assertTrue(meta_cat_model.meta_cat_dir.endswith("addon_meta_cat.Status"))
 
 

--- a/medcat-trainer/webapp/api/api/tests/test_model_pack_addons.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_pack_addons.py
@@ -23,7 +23,7 @@ from unittest.mock import MagicMock, patch
 from django.core.files.base import ContentFile
 from django.test import TestCase, override_settings
 
-from ..models import ModelPack
+from ..models import ModelPack, MetaCATModel
 
 
 def _make_meta_cat_addon_cnf(category_name="Status", model_name="bert"):
@@ -126,3 +126,20 @@ class ModelPackAddonRegistrationTests(TestCase):
         self.assertIsNotNone(model_pack.concept_db)
         self.assertIsNotNone(model_pack.vocab)
         self.assertEqual(model_pack.meta_cats.count(), 0)
+
+
+    def test_re_register_model_pack_with_same_meta_cat_does_not_create_duplicate(self):
+        model_pack, _ = self._prepare_model_pack(name="dupe-addon-pack")
+        addon_cnfs = [
+            _make_meta_cat_addon_cnf(),
+            _make_meta_cat_addon_cnf(category_name="Subject"),]
+        # once
+        with self._register_model_pack(model_pack, addon_cnfs):
+            pass
+        # new model pack
+        model_pack2, _ = self._prepare_model_pack(name="dupe-addon-pack-2")
+        # and register again
+        with self._register_model_pack(model_pack2, addon_cnfs):
+            pass
+        registered_meta_cats = MetaCATModel.objects.all()
+        self.assertEqual(len(registered_meta_cats), len(addon_cnfs))

--- a/medcat-trainer/webapp/api/api/tests/test_model_pack_addons.py
+++ b/medcat-trainer/webapp/api/api/tests/test_model_pack_addons.py
@@ -71,7 +71,7 @@ class ModelPackAddonRegistrationTests(TestCase):
         self.assertIsNotNone(model_pack.vocab)
         self.assertEqual(model_pack.meta_cats.count(), 1)
         meta_cat_model = model_pack.meta_cats.get()
-        self.assertEqual(meta_cat_model.name, "Status - bert - 1")
+        self.assertEqual(meta_cat_model.name, "Status - bert - from 1")
         self.assertTrue(meta_cat_model.meta_cat_dir.endswith("addon_meta_cat.Status"))
 
     def test_register_model_pack_with_rel_cat_only(self):
@@ -98,7 +98,7 @@ class ModelPackAddonRegistrationTests(TestCase):
         self.assertEqual(model_pack.meta_cats.count(), 2)
         self.assertEqual(
             set(model_pack.meta_cats.values_list("name", flat=True)),
-            {"Status - bert - 1", "Experiencer - roberta - 1"},
+            {"Status - bert - from 1", "Experiencer - roberta - from 1"},
         )
 
     def test_register_model_pack_with_meta_cat_and_rel_cat(self):


### PR DESCRIPTION
When uploading a model with meta cats that have the same name as ones that already exist on trianer, the current implementation tries to re-register the meta cat with the same name. But that fails due to the duplicate name.

This PR addresses that by changing the name when it already exists and saves the meta-cats with a unique name in such cases.

The idea is to avoid trying to save the duplicate while allowing for similarly named (potentially) different meta cats.

