### PR TITLE
fix(medcat-trainer): Support uploading model packs with longer local filenames

### DIFF
--- a/medcat-trainer/docker-compose-dev.yml
+++ b/medcat-trainer/docker-compose-dev.yml
@@ -10,9 +10,6 @@ services:
     restart: always
     networks:
       - gateway-auth_gateway-net
-      - default
-    depends_on:
-      - trainer-postgres
     volumes:
       - api-media:/home/api/media
       - api-static:/home/api/static
@@ -38,25 +35,8 @@ services:
       - KEYCLOAK_INTERNAL_SERVICE_URL=http://keycloak:8080
       - KEYCLOAK_BACKEND_CLIENT_ID=cogstack-medcattrainer-backend
       - KEYCLOAK_BACKEND_CLIENT_SECRET=***
-      - DB_ENGINE=postgresql
-      - DB_NAME=postgres
-      - DB_USER=admin
-      - DB_PASSWORD=admin
-      - DB_HOST=trainer-postgres
-      - DB_PORT=5432
     command: /usr/bin/supervisord -c /etc/supervisord.conf
-  trainer-postgres:
-    image: postgres:17.6-alpine
-    restart: always
-    environment:
-      - POSTGRES_USER=admin
-      - POSTGRES_PASSWORD=admin
-    volumes:
-      - postgres-vol:/var/lib/postgresql/data
-    ports:
-      - 5432:5432
-    networks:
-      - default
+
   nginx:
     image: nginx
     restart: always
@@ -101,7 +81,7 @@ volumes:
   api-db:
   api-db-backup:
   solr-data:
-  postgres-vol:
+
 networks:
   gateway-auth_gateway-net:
     name: ${MCT_GATEWAY_NETWORK_NAME:-gateway-auth_gateway-net}

--- a/medcat-trainer/docker-compose-dev.yml
+++ b/medcat-trainer/docker-compose-dev.yml
@@ -10,6 +10,9 @@ services:
     restart: always
     networks:
       - gateway-auth_gateway-net
+      - default
+    depends_on:
+      - trainer-postgres
     volumes:
       - api-media:/home/api/media
       - api-static:/home/api/static
@@ -35,8 +38,25 @@ services:
       - KEYCLOAK_INTERNAL_SERVICE_URL=http://keycloak:8080
       - KEYCLOAK_BACKEND_CLIENT_ID=cogstack-medcattrainer-backend
       - KEYCLOAK_BACKEND_CLIENT_SECRET=***
+      - DB_ENGINE=postgresql
+      - DB_NAME=postgres
+      - DB_USER=admin
+      - DB_PASSWORD=admin
+      - DB_HOST=trainer-postgres
+      - DB_PORT=5432
     command: /usr/bin/supervisord -c /etc/supervisord.conf
-
+  trainer-postgres:
+    image: postgres:17.6-alpine
+    restart: always
+    environment:
+      - POSTGRES_USER=admin
+      - POSTGRES_PASSWORD=admin
+    volumes:
+      - postgres-vol:/var/lib/postgresql/data
+    ports:
+      - 5432:5432
+    networks:
+      - default
   nginx:
     image: nginx
     restart: always
@@ -81,7 +101,7 @@ volumes:
   api-db:
   api-db-backup:
   solr-data:
-
+  postgres-vol:
 networks:
   gateway-auth_gateway-net:
     name: ${MCT_GATEWAY_NETWORK_NAME:-gateway-auth_gateway-net}

--- a/medcat-trainer/webapp/api/api/migrations/0095_widen_model_pack_path_fields.py
+++ b/medcat-trainer/webapp/api/api/migrations/0095_widen_model_pack_path_fields.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0094_alter_project_options_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='conceptdb',
+            name='cdb_file',
+            field=models.FileField(max_length=255, upload_to=''),
+        ),
+        migrations.AlterField(
+            model_name='metacatmodel',
+            name='meta_cat_dir',
+            field=models.FilePathField(
+                allow_folders=True,
+                editable=False,
+                help_text='The zip or dir for a MetaCAT model, not editable, is set via a model pack .zip upload',
+                max_length=255,
+            ),
+        ),
+        migrations.AlterField(
+            model_name='modelpack',
+            name='model_pack',
+            field=models.FileField(help_text='Model pack zip', max_length=255, upload_to=''),
+        ),
+        migrations.AlterField(
+            model_name='vocabulary',
+            name='vocab_file',
+            field=models.FileField(max_length=255, upload_to=''),
+        ),
+    ]

--- a/medcat-trainer/webapp/api/api/models.py
+++ b/medcat-trainer/webapp/api/api/models.py
@@ -37,7 +37,7 @@ logger = logging.getLogger(__name__)
 
 class ModelPack(models.Model):
     name = models.TextField(help_text='', unique=True)
-    model_pack = models.FileField(help_text='Model pack zip')
+    model_pack = models.FileField(max_length=255, help_text='Model pack zip')
     concept_db = models.ForeignKey('ConceptDB', on_delete=models.CASCADE, blank=True, null=True)
     vocab = models.ForeignKey('Vocabulary', on_delete=models.CASCADE, blank=True, null=True)
     meta_cats = models.ManyToManyField('MetaCATModel', blank=True, default=None)
@@ -149,7 +149,7 @@ class ModelPack(models.Model):
 
 class ConceptDB(models.Model):
     name = models.CharField(max_length=100, default='', blank=True, validators=[cdb_name_validator], unique=True)
-    cdb_file = models.FileField()
+    cdb_file = models.FileField(max_length=255)
     use_for_training = models.BooleanField(default=True)
     create_time = models.DateTimeField(auto_now_add=True)
     last_modified = models.DateTimeField(auto_now=True)
@@ -185,7 +185,7 @@ class ConceptDB(models.Model):
 
 class Vocabulary(models.Model):
     name = models.CharField(max_length=100, default='', blank=True)
-    vocab_file = models.FileField()
+    vocab_file = models.FileField(max_length=255)
     create_time = models.DateTimeField(auto_now_add=True)
     last_modified = models.DateTimeField(auto_now=True)
     last_modified_by = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE, default=None, null=True)
@@ -207,7 +207,7 @@ class Vocabulary(models.Model):
 
 class MetaCATModel(models.Model):
     name = models.CharField(max_length=100, help_text="The task name followed by the underlying model impl", unique=True)
-    meta_cat_dir = models.FilePathField(help_text='The zip or dir for a MetaCAT model, not editable, '
+    meta_cat_dir = models.FilePathField(max_length=255, help_text='The zip or dir for a MetaCAT model, not editable, '
                                                   'is set via a model pack .zip upload',
                                         allow_folders=True, editable=False)
 


### PR DESCRIPTION

## Issue

- I run medcat trainer with postgres
- I have a model pack on disk with a very long name 
- I try saving the model pack, it errors with this error

`[medcattrainer] psycopg.errors.StringDataRightTruncation: value too long for type character varying(100)`




## Fix

For now, I've just updated the column size to handle longer ones. This felt like the easiest fix with the least impact. 

The right thing to do is probably that we shouldnt use the file path of the file on the users disk at all here. Decided we can do this later in order to get this fixed today. 

## Details

- Django FileField defaults to 100 characters  if max_length isnt set
- Only postgres use errors here. Sqlite doesnt actually check the constraints
- `    model_pack = models.FileField(max_length=255, help_text='Model pack zip')`


## Logs
Two errors possible, if theres a metacat it fails first. Else it later then fails on CDB.

```

```
[medcattrainer] Internal Server Error: /api/modelpacks/
[medcattrainer] Traceback (most recent call last):
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute
[medcattrainer]     return self.cursor.execute(sql, params)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/psycopg/cursor.py", line 117, in execute
[medcattrainer]     raise ex.with_traceback(None)
[medcattrainer] psycopg.errors.StringDataRightTruncation: value too long for type character varying(100)
[medcattrainer] 
[medcattrainer] The above exception was the direct cause of the following exception:
[medcattrainer] 
[medcattrainer] Traceback (most recent call last):
[medcattrainer]   File "/home/api/api/models.py", line 169, in save
[medcattrainer]     concept_db.save(skip_load=True)
[medcattrainer]   File "/home/api/api/models.py", line 330, in save
[medcattrainer]     super().save(*args, **kwargs)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 902, in save
[medcattrainer]     self.save_base(
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 1008, in save_base
[medcattrainer]     updated = self._save_table(
[medcattrainer]               ^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 1169, in _save_table
[medcattrainer]     results = self._do_insert(
[medcattrainer]               ^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 1210, in _do_insert
[medcattrainer]     return manager._insert(
[medcattrainer]            ^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
[medcattrainer]     return getattr(self.get_queryset(), name)(*args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/query.py", line 1873, in _insert
[medcattrainer]     return query.get_compiler(using=using).execute_sql(returning_fields)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/sql/compiler.py", line 1882, in execute_sql
[medcattrainer]     cursor.execute(sql, params)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 122, in execute
[medcattrainer]     return super().execute(sql, params)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 79, in execute
[medcattrainer]     return self._execute_with_wrappers(
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers
[medcattrainer]     return executor(sql, params, many, context)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 100, in _execute
[medcattrainer]     with self.db.wrap_database_errors:
[medcattrainer]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/utils.py", line 91, in __exit__
[medcattrainer]     raise dj_exc_value.with_traceback(traceback) from exc_value
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute
[medcattrainer]     return self.cursor.execute(sql, params)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/psycopg/cursor.py", line 117, in execute
[medcattrainer]     raise ex.with_traceback(None)
[medcattrainer] django.db.utils.DataError: value too long for type character varying(100)
[medcattrainer] 
[medcattrainer] The above exception was the direct cause of the following exception:
[medcattrainer] 
[medcattrainer] Traceback (most recent call last):
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
[medcattrainer]     response = get_response(request)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
[medcattrainer]     response = wrapped_callback(request, *callback_args, **callback_kwargs)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
[medcattrainer]     return view_func(request, *args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/viewsets.py", line 125, in view
[medcattrainer]     return self.dispatch(request, *args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 515, in dispatch
[medcattrainer]     response = self.handle_exception(exc)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 475, in handle_exception
[medcattrainer]     self.raise_uncaught_exception(exc)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
[medcattrainer]     raise exc
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 512, in dispatch
[medcattrainer]     response = handler(request, *args, **kwargs)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/mixins.py", line 19, in create
[medcattrainer]     self.perform_create(serializer)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/mixins.py", line 24, in perform_create
[medcattrainer]     serializer.save()
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/serializers.py", line 210, in save
[medcattrainer]     self.instance = self.create(validated_data)
[medcattrainer]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/serializers.py", line 991, in create
[medcattrainer]     instance = ModelClass._default_manager.create(**validated_data)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
[medcattrainer]     return getattr(self.get_queryset(), name)(*args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/query.py", line 665, in create
[medcattrainer]     obj.save(force_insert=True, using=self.db)
[medcattrainer]   File "/usr/local/lib/python3.12/contextlib.py", line 81, in inner
[medcattrainer]     return func(*args, **kwds)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/api/api/models.py", line 187, in save
[medcattrainer]     raise FileNotFoundError(f'Error loading the CDB from this model pack: {self.model_pack.path}') from exc
[medcattrainer] FileNotFoundError: Error loading the CDB from this model pack: /home/api/media/mct2_model_pack_long_name_000000000011111111112222222222333333333344444444445555555555_RehltKC.zip
[medcattrainer] ERROR 2026-07-17 10:39:01,744 log.py l:253:Internal Server Error: /api/modelpacks/
[medcattrainer] Traceback (most recent call last):
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute
[medcattrainer]     return self.cursor.execute(sql, params)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/psycopg/cursor.py", line 117, in execute
[medcattrainer]     raise ex.with_traceback(None)
[medcattrainer] psycopg.errors.StringDataRightTruncation: value too long for type character varying(100)
[medcattrainer] 
[medcattrainer] The above exception was the direct cause of the following exception:
[medcattrainer] 
[medcattrainer] Traceback (most recent call last):
[medcattrainer]   File "/home/api/api/models.py", line 169, in save
[medcattrainer]     concept_db.save(skip_load=True)
[medcattrainer]   File "/home/api/api/models.py", line 330, in save
[medcattrainer]     super().save(*args, **kwargs)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 902, in save
[medcattrainer]     self.save_base(
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 1008, in save_base
[medcattrainer]     updated = self._save_table(
[medcattrainer]               ^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 1169, in _save_table
[medcattrainer]     results = self._do_insert(
[medcattrainer]               ^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/base.py", line 1210, in _do_insert
[medcattrainer]     return manager._insert(
[medcattrainer]            ^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
[medcattrainer]     return getattr(self.get_queryset(), name)(*args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/query.py", line 1873, in _insert
[medcattrainer]     return query.get_compiler(using=using).execute_sql(returning_fields)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/sql/compiler.py", line 1882, in execute_sql
[medcattrainer]     cursor.execute(sql, params)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 122, in execute
[medcattrainer]     return super().execute(sql, params)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 79, in execute
[medcattrainer]     return self._execute_with_wrappers(
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 92, in _execute_with_wrappers
[medcattrainer]     return executor(sql, params, many, context)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 100, in _execute
[medcattrainer]     with self.db.wrap_database_errors:
[medcattrainer]          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/utils.py", line 91, in __exit__
[medcattrainer]     raise dj_exc_value.with_traceback(traceback) from exc_value
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute
[medcattrainer]     return self.cursor.execute(sql, params)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/psycopg/cursor.py", line 117, in execute
[medcattrainer]     raise ex.with_traceback(None)
[medcattrainer] django.db.utils.DataError: value too long for type character varying(100)
[medcattrainer] 
[medcattrainer] The above exception was the direct cause of the following exception:
[medcattrainer] 
[medcattrainer] Traceback (most recent call last):
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
[medcattrainer]     response = get_response(request)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/core/handlers/base.py", line 197, in _get_response
[medcattrainer]     response = wrapped_callback(request, *callback_args, **callback_kwargs)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/views/decorators/csrf.py", line 65, in _view_wrapper
[medcattrainer]     return view_func(request, *args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/viewsets.py", line 125, in view
[medcattrainer]     return self.dispatch(request, *args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 515, in dispatch
[medcattrainer]     response = self.handle_exception(exc)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 475, in handle_exception
[medcattrainer]     self.raise_uncaught_exception(exc)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 486, in raise_uncaught_exception
[medcattrainer]     raise exc
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/views.py", line 512, in dispatch
[medcattrainer]     response = handler(request, *args, **kwargs)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/mixins.py", line 19, in create
[medcattrainer]     self.perform_create(serializer)
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/mixins.py", line 24, in perform_create
[medcattrainer]     serializer.save()
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/serializers.py", line 210, in save
[medcattrainer]     self.instance = self.create(validated_data)
[medcattrainer]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/rest_framework/serializers.py", line 991, in create
[medcattrainer]     instance = ModelClass._default_manager.create(**validated_data)
[medcattrainer]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/manager.py", line 87, in manager_method
[medcattrainer]     return getattr(self.get_queryset(), name)(*args, **kwargs)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/models/query.py", line 665, in create
[medcattrainer]     obj.save(force_insert=True, using=self.db)
[medcattrainer]   File "/usr/local/lib/python3.12/contextlib.py", line 81, in inner
[medcattrainer]     return func(*args, **kwds)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/api/api/models.py", line 187, in save
[medcattrainer]     raise FileNotFoundError(f'Error loading the CDB from this model pack: {self.model_pack.path}') from exc
[medcattrainer] FileNotFoundError: Error loading the CDB from this model pack: /home/api/media/mct2_model_pack_long_name_000000000011111111112222222222333333333344444444445555555555_RehltKC.zip

```




```

[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/psycopg/cursor.py", line 117, in execute
[medcattrainer]     raise ex.with_traceback(None)
[medcattrainer] django.db.utils.DataError: value too long for type character varying(100)
[medcattrainer] 

...

[medcattrainer]     raise MedCATLoadException(f'Failure loading MetaCAT models - {unpacked_model_pack_path}') from exc
[medcattrainer] api.models.MedCATLoadException: Failure loading MetaCAT models - /home/api/media/<redacted>
[medcattrainer] ERROR 2026-07-15 15:44:56,875 log.py l:253:Internal Server Error: /api/modelpacks/
[medcattrainer] Traceback (most recent call last):
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/django/db/backends/utils.py", line 105, in _execute
[medcattrainer]     return self.cursor.execute(sql, params)
[medcattrainer]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[medcattrainer]   File "/home/.venv/lib/python3.12/site-packages/psycopg/cursor.py", line 117, in execute
[medcattrainer]     raise ex.with_traceback(None)
[medcattrainer] psycopg.errors.StringDataRightTruncation: value too long for type character varying(100)
```


