### PR TITLE
fix(medcat-trainer): CU-86994wn8k: improve session state management

### DIFF
--- a/medcat-trainer/webapp/frontend/src/App.vue
+++ b/medcat-trainer/webapp/frontend/src/App.vue
@@ -66,7 +66,7 @@ import Login from '@/components/common/Login.vue'
 import EventBus from '@/event-bus'
 import { isOidcEnabled, getRuntimeConfig } from './runtimeConfig';
 import { getMenuItems } from './plugins/registry'
-import { UNAUTHORIZED_EVENT, resetUnauthorizedGuard } from './httpAuth'
+import { UNAUTHORIZED_EVENT, resetUnauthorizedGuard, clearClientAuth } from './httpAuth'
 
 export default {
   name: 'App',
@@ -138,9 +138,12 @@ export default {
     logout () {
       this.uname = null
       this.isAdmin = false
+      // Clear header + cookies together so a refresh cannot resurrect a half-logged-in state.
+      clearClientAuth(this.$http)
       this.$cookies.remove('username')
       this.$cookies.remove('api-token')
       this.$cookies.remove('admin')
+      this.$cookies.remove('user-id')
 
       if (this.useOidc && this.$keycloak && this.$keycloak.authenticated) {
         this.$keycloak.logout({

--- a/medcat-trainer/webapp/frontend/src/httpAuth.ts
+++ b/medcat-trainer/webapp/frontend/src/httpAuth.ts
@@ -15,6 +15,14 @@ const AUTH_COOKIES = ['api-token', 'username', 'admin', 'user-id']
 // single re-login prompt. Reset via resetUnauthorizedGuard() on login success.
 let handlingUnauthorized = false
 
+/** Clear axios Authorization and auth cookies together so they cannot diverge. */
+export function clearClientAuth(http: AxiosInstance): void {
+  delete http.defaults.headers.common['Authorization']
+  for (const name of AUTH_COOKIES) {
+    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
+  }
+}
+
 /** Clear stale auth state and notify the app that re-login is required. */
 export function handleUnauthorized(http: AxiosInstance): void {
   if (handlingUnauthorized) {
@@ -22,12 +30,31 @@ export function handleUnauthorized(http: AxiosInstance): void {
   }
   handlingUnauthorized = true
 
-  delete http.defaults.headers.common['Authorization']
-  for (const name of AUTH_COOKIES) {
-    document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
-  }
-
+  clearClientAuth(http)
   EventBus.$emit(UNAUTHORIZED_EVENT)
+}
+
+/**
+ * Traditional (non-OIDC) auth gate for project views.
+ *
+ * - No token cookie → force re-login (clears any leftover Authorization header).
+ * - Token cookie present but Authorization header missing → restore the header
+ *   so in-memory axios state matches the durable cookie.
+ *
+ * Returns false when the caller must stop and wait for re-login.
+ */
+export function ensureTraditionalAuth(
+  http: AxiosInstance,
+  token: string | null | undefined
+): boolean {
+  if (!token) {
+    handleUnauthorized(http)
+    return false
+  }
+  if (!http.defaults.headers.common['Authorization']) {
+    http.defaults.headers.common['Authorization'] = `Token ${token}`
+  }
+  return true
 }
 
 /** Re-arm the guard once the user has successfully re-authenticated. */

--- a/medcat-trainer/webapp/frontend/src/tests/httpAuth.spec.ts
+++ b/medcat-trainer/webapp/frontend/src/tests/httpAuth.spec.ts
@@ -3,7 +3,9 @@ import {
   UNAUTHORIZED_EVENT,
   handleUnauthorized,
   resetUnauthorizedGuard,
-  registerUnauthorizedInterceptor
+  registerUnauthorizedInterceptor,
+  ensureTraditionalAuth,
+  clearClientAuth
 } from '@/httpAuth'
 import EventBus from '@/event-bus'
 
@@ -54,6 +56,18 @@ describe('httpAuth unauthorized handling', () => {
     expect(onEvent).toHaveBeenCalledTimes(1)
   })
 
+  it('clearClientAuth clears header and cookies without emitting', () => {
+    const http = makeHttpStub()
+    const onEvent = vi.fn()
+    EventBus.$on(UNAUTHORIZED_EVENT, onEvent)
+
+    clearClientAuth(http as never)
+
+    expect(http.defaults.headers.common['Authorization']).toBeUndefined()
+    expect(document.cookie).not.toContain('api-token=value')
+    expect(onEvent).not.toHaveBeenCalled()
+  })
+
   it('only prompts once for a burst of 401s until the guard is reset', () => {
     const http = makeHttpStub()
     const onEvent = vi.fn()
@@ -91,5 +105,26 @@ describe('httpAuth unauthorized handling', () => {
     expect(onEvent).not.toHaveBeenCalled()
     // A successful response passes through untouched.
     expect(http.handlers.onFulfilled!({ ok: true })).toEqual({ ok: true })
+  })
+
+  it('ensureTraditionalAuth restores a missing Authorization header from the cookie', () => {
+    const http = makeHttpStub()
+    delete http.defaults.headers.common['Authorization']
+    const onEvent = vi.fn()
+    EventBus.$on(UNAUTHORIZED_EVENT, onEvent)
+
+    expect(ensureTraditionalAuth(http as never, 'fresh-token')).toBe(true)
+    expect(http.defaults.headers.common['Authorization']).toBe('Token fresh-token')
+    expect(onEvent).not.toHaveBeenCalled()
+  })
+
+  it('ensureTraditionalAuth forces re-login when the token cookie is missing', () => {
+    const http = makeHttpStub()
+    const onEvent = vi.fn()
+    EventBus.$on(UNAUTHORIZED_EVENT, onEvent)
+
+    expect(ensureTraditionalAuth(http as never, null)).toBe(false)
+    expect(http.defaults.headers.common['Authorization']).toBeUndefined()
+    expect(onEvent).toHaveBeenCalledTimes(1)
   })
 })

--- a/medcat-trainer/webapp/frontend/src/tests/views/Home.spec.ts
+++ b/medcat-trainer/webapp/frontend/src/tests/views/Home.spec.ts
@@ -72,7 +72,7 @@ describe('Home.vue', () => {
           if (url.startsWith('/api/project-groups/')) {
               return Promise.resolve({ data: { results: [] } });
           }
-          
+
           return Promise.resolve({});
       });
 
@@ -105,5 +105,81 @@ describe('Home.vue', () => {
     expect(mockGet).toHaveBeenCalledWith('/api/concept-db-search-index-created/?cdbs=');
     expect(mockGet).toHaveBeenCalledWith('/api/project-progress/?projects=1');
     expect(mockGet).toHaveBeenCalledWith('/api/project-groups/?id__in=');
+  });
+
+  it('does not wipe auth cookies when project fetch fails with a non-401 error', async () => {
+    const mockGet = vi.fn((url: string) => {
+      if (url === '/api/behind-rp/') {
+        return Promise.resolve({ data: true });
+      }
+      if (url === '/api/project-annotate-entities/') {
+        return Promise.reject({ response: { status: 500, data: { message: 'boom' } } });
+      }
+      return Promise.resolve({});
+    });
+    const mockCookies = {
+      get: vi.fn((key: string) => {
+        if (key === 'api-token') return 'token';
+        if (key === 'admin') return 'false';
+        return null;
+      }),
+      remove: vi.fn()
+    };
+
+    const wrapper = mount(Home, {
+      global: {
+        plugins: [router],
+        mocks: {
+          $http: { get: mockGet },
+          $cookies: mockCookies
+        },
+        stubs: ['login', 'modal', 'project-list', 'v-data-table', 'transition', 'router-link', 'router-view']
+      }
+    });
+
+    await router.isReady();
+    await flushPromises();
+
+    expect(mockCookies.remove).not.toHaveBeenCalled();
+    expect(wrapper.vm.loginSuccessful).toBe(true);
+    expect(wrapper.vm.loadingProjects).toBe(false);
+  });
+
+  it('marks login unsuccessful on 401 without clearing cookies itself', async () => {
+    const mockGet = vi.fn((url: string) => {
+      if (url === '/api/behind-rp/') {
+        return Promise.resolve({ data: true });
+      }
+      if (url === '/api/project-annotate-entities/') {
+        return Promise.reject({ response: { status: 401, data: { detail: 'Invalid token.' } } });
+      }
+      return Promise.resolve({});
+    });
+    const mockCookies = {
+      get: vi.fn((key: string) => {
+        if (key === 'api-token') return 'token';
+        if (key === 'admin') return 'false';
+        return null;
+      }),
+      remove: vi.fn()
+    };
+
+    const wrapper = mount(Home, {
+      global: {
+        plugins: [router],
+        mocks: {
+          $http: { get: mockGet },
+          $cookies: mockCookies
+        },
+        stubs: ['login', 'modal', 'project-list', 'v-data-table', 'transition', 'router-link', 'router-view']
+      }
+    });
+
+    await router.isReady();
+    await flushPromises();
+
+    // Cookie wipe is owned by httpAuth on 401; Home must not double-clear.
+    expect(mockCookies.remove).not.toHaveBeenCalled();
+    expect(wrapper.vm.loginSuccessful).toBe(false);
   });
 });

--- a/medcat-trainer/webapp/frontend/src/tests/views/TrainAnnotations.spec.ts
+++ b/medcat-trainer/webapp/frontend/src/tests/views/TrainAnnotations.spec.ts
@@ -26,14 +26,20 @@ const project = {
 
 // Mount the view without triggering the created() data-fetch cascade: the default
 // $http.get returns a promise that never settles so we can drive fetchEntities directly.
-const mountView = (getImpl: (url: string) => Promise<unknown>) => {
+const mountView = (getImpl: (url: string) => Promise<unknown>, cookies: Record<string, string> = { 'api-token': 'test-token' }) => {
   const mockGet = vi.fn(getImpl)
   const wrapper = shallowMount(TrainAnnotations, {
     props: { projectId: 1 },
     global: {
       plugins: [router],
       mocks: {
-        $http: { get: mockGet }
+        $http: {
+          get: mockGet,
+          defaults: { headers: { common: { Authorization: 'Token test-token' } } }
+        },
+        $cookies: {
+          get: vi.fn((key: string) => cookies[key] ?? null)
+        }
       }
     }
   })
@@ -165,5 +171,17 @@ describe('TrainAnnotations.vue fetchEntities', () => {
     expect(wrapper.vm.loadingMsg).toBeNull()
     expect(wrapper.vm.ents).toHaveLength(1)
     expect(wrapper.vm.currentEnt.id).toBe(10)
+  })
+
+  it('does not load a document when the auth cookie is missing', async () => {
+    const { wrapper, mockGet } = mountView(() => new Promise(() => {}), {})
+    mockGet.mockClear()
+
+    wrapper.vm.project = project
+    wrapper.vm.loadDoc({ id: 123, text: 'clinical note' })
+    await flushPromises()
+
+    expect(mockGet).not.toHaveBeenCalled()
+    expect(wrapper.vm.currentDoc).toBeNull()
   })
 })

--- a/medcat-trainer/webapp/frontend/src/views/Home.vue
+++ b/medcat-trainer/webapp/frontend/src/views/Home.vue
@@ -133,13 +133,15 @@ export default {
           } else {
             this.postLoadedProjects()
           }
-        }).catch(() => {
-          this.$cookies.remove('username')
-          this.$cookies.remove('api-token')
-          this.$cookies.remove('admin')
-          this.$cookies.remove('user-id')
+        }).catch((err) => {
           this.loadingProjects = false
-          this.loginSuccessful = false
+          // 401: httpAuth interceptor already clears cookie + Authorization together
+          // and opens the re-login prompt. Do not wipe cookies on other failures —
+          // that left Authorization in memory while removing the cookie, so the tab
+          // still sent a token until refresh forced an unexplained re-login.
+          if (err.response?.status === 401) {
+            this.loginSuccessful = false
+          }
         })
       }
     },

--- a/medcat-trainer/webapp/frontend/src/views/TrainAnnotations.vue
+++ b/medcat-trainer/webapp/frontend/src/views/TrainAnnotations.vue
@@ -315,6 +315,8 @@ import RelationAnnotationTaskContainer from '@/components/usecases/RelationAnnot
 import AnnotationSummary from '@/components/common/AnnotationSummary.vue'
 import ConceptFilter from "@/components/common/ConceptFilter.vue"
 import {Splitpanes, Pane} from 'splitpanes'
+import { ensureTraditionalAuth } from '@/httpAuth'
+import { isOidcEnabled } from '@/runtimeConfig'
 
 const TASK_NAME = 'Concept Annotation'
 const CONCEPT_CORRECT = 'Correct'
@@ -403,13 +405,31 @@ export default {
     this.fetchAnnoConf()
   },
   methods: {
+    ensureProjectAuth() {
+      if (isOidcEnabled()) {
+        if (this.$keycloak && !this.$keycloak.authenticated) {
+          this.$keycloak.login()
+          return false
+        }
+        return true
+      }
+      // Sync cookie ↔ Authorization header (or force re-login if the cookie is gone).
+      return ensureTraditionalAuth(this.$http, this.$cookies.get('api-token'))
+    },
     fetchAnnoConf() {
+      if (!this.ensureProjectAuth()) {
+        return
+      }
       this.$http.get(`/api/anno-conf/`).then(resp => {
         LOAD_NUM_DOC_PAGES = resp.data['LOAD_NUM_DOC_PAGES'] || LOAD_NUM_DOC_PAGES
         this.fetchData()
       })
     },
     fetchData() {
+      // Re-check when loading the project: cookie may have been cleared in another tab.
+      if (!this.ensureProjectAuth()) {
+        return
+      }
       this.$http.get(`/api/project-annotate-entities/?id=${this.projectId}`).then(resp => {
         if (resp.data.count === 0) {
           this.errors.modal = true
@@ -496,6 +516,9 @@ export default {
       }
     },
     loadDoc(doc) {
+      if (!this.ensureProjectAuth()) {
+        return
+      }
       this.currentDoc = doc
       if (String(this.$route.params.docId) !== String(doc.id)) {
         this.$router.replace({


### PR DESCRIPTION
- only clear session state on 401s. 
- 401s on `/train-annotations/` now fails gracefully, promtping a session auth refresh (i.e. relogin)

once this is in dev will need to test if the OIDC auth  / Keycloak auth to check that's still working correctly