### PR TITLE
build(cogstack-es): Pin ruff to earlier versions to avoid workflow failures

### DIFF
--- a/cogstack-es/pyproject.toml
+++ b/cogstack-es/pyproject.toml
@@ -34,7 +34,9 @@ dev = [
     "pandas-stubs",
     "types-tqdm",
     "pytest",
-    "ruff",
+    # NOTE: ruff 0.16.0 introduces new checks that I am unwilling
+    #       to tackle at this point in time
+    "ruff<0.16.0",
     "nbconvert",
 ]
 ES8 = [


### PR DESCRIPTION
Turns out ruff `v0.16.x` introduced new checks that I do not wish to tackle at this point.

E.g:
- I001 [*] Import block is un-sorted or un-formatted
- UP035 [*] Import from `collections.abc` instead: `Iterable`, `Sequence`
- UP035 `typing.Type` is deprecated, use `type` instead
- UP007 [*] Use `X | Y` for type annotations
- UP045 [*] Use `X | None` for type annotations