### PR TITLE
fix(medcat): Fix config defaulting to train=True.

### DIFF
--- a/medcat-v2/medcat/config/config.py
+++ b/medcat-v2/medcat/config/config.py
@@ -368,7 +368,7 @@ class Linking(ComponentConfig):
     some point. Should add up to 1."""
     filters: LinkingFilters = LinkingFilters()
     """Filters"""
-    train: bool = True
+    train: bool = False
     """Should it train or not, this is set automatically ignore in 99% of
     cases and do not set manually"""
     random_replacement_unsupervised: float = 0.80


### PR DESCRIPTION
This default would normally be fixed at model load time or at inference time (see calls to ). However, when building a new model (e.g with a mostly default config), the value would remain . And if there is no save/load or inference before training, this would fail to train because of it.

PS: To reiterate, this would not have affected any users down the line since there's fixes at model load time. This would have only affected new model creation (with default/unchanged config).