### PR TITLE
feat(medcat-trainer): ProjectGroups management via /project-admin/

### DIFF
--- a/medcat-trainer/webapp/api/api/admin/models.py
+++ b/medcat-trainer/webapp/api/api/admin/models.py
@@ -6,6 +6,7 @@ from django.shortcuts import get_object_or_404
 
 from .actions import *
 from ..models import *
+from ..project_groups import create_projects_for_group, update_projects_for_group
 
 _PROJECT_ANNO_ENTS_SETTINGS_FIELD_ORDER = (
     'concept_db', 'vocab', 'model_pack', 'cdb_search_filter', 'deid_model_annotation', 'require_entity_validation', 'train_model_on_submit',
@@ -80,44 +81,6 @@ class ProjectGroupAdmin(admin.ModelAdmin):
         form = super().get_form(request, obj, **kwargs)
         return form
 
-    def _set_proj_from_group(self, proj: ProjectAnnotateEntities, group: ProjectGroup,
-                             annotator: settings.AUTH_USER_MODEL, admins: List[User],
-                             cdb_search_filters: List[ConceptDB], tasks: List[MetaTask], relations: List[Relation]):
-        proj.group = group
-        proj.name = f'{group.name} - {str(annotator)}'
-        proj.description = group.description
-        proj.dataset = group.dataset
-        proj.annotation_guideline_link = group.annotation_guideline_link
-        proj.create_time = group.create_time
-        proj.cuis = group.cuis
-        proj.cuis_file = group.cuis_file
-        proj.annotation_classification = group.annotation_classification
-        proj.project_locked = group.project_locked
-        proj.project_status = group.project_status
-        proj.concept_db = group.concept_db
-        proj.vocab = group.vocab
-        proj.model_pack = group.model_pack
-        proj.deid_model_annotation = group.deid_model_annotation
-        proj.use_model_service = group.use_model_service
-        proj.model_service_url = group.model_service_url
-        proj.require_entity_validation = group.require_entity_validation
-        proj.train_model_on_submit = group.train_model_on_submit
-        proj.add_new_entities = group.add_new_entities
-        proj.restrict_concept_lookup = group.restrict_concept_lookup
-        proj.terminate_available = group.terminate_available
-        proj.irrelevant_available = group.irrelevant_available
-        proj.enable_entity_annotation_comments = group.enable_entity_annotation_comments
-
-        # project specific attrs / m2m fields
-        proj.save()
-        proj.cdb_search_filter.set(cdb_search_filters)
-        proj.members.set(admins)
-        proj.members.add(annotator)
-        proj.tasks.set(tasks)
-        proj.relations.set(relations)
-        proj.save()
-        return proj
-
     def save_model(self, request, obj, form, change):
         super().save_model(request, obj, form, change)
         annotators = [get_object_or_404(User, pk=id) for id in request.POST.getlist('annotators')]
@@ -126,25 +89,25 @@ class ProjectGroupAdmin(admin.ModelAdmin):
         tasks = [get_object_or_404(MetaTask, pk=id) for id in request.POST.getlist('tasks')]
         relations = [get_object_or_404(Relation, pk=id) for id in request.POST.getlist('relations')]
 
-        # create the underlying ProjectAnnotateEntities models or edit them
         if obj.create_associated_projects:
             if not change:
-                # new ProjectGroup being created
-                for annotator in annotators:
-                    self._set_proj_from_group(ProjectAnnotateEntities(), obj, annotator,
-                                              admins, cdb_search_filters, tasks, relations)
+                create_projects_for_group(
+                    obj,
+                    annotators=annotators,
+                    admins=admins,
+                    cdb_search_filters=cdb_search_filters,
+                    tasks=tasks,
+                    relations=relations,
+                )
             else:
-                # applying these settings to all previously created projects within this group
-                projs = ProjectAnnotateEntities.objects.filter(group=obj)
-                if len(projs) == len(obj.annotators.all()):
-                    for proj, annotator in zip(projs, obj.annotators.all()):
-                       self._set_proj_from_group(proj, obj, annotator, admins, cdb_search_filters,
-                                                 tasks, relations)
-                else:
-                    raise ValueError("Attempting to update a ProjectGroup but one or more "
-                                     "of underlying ProjectAnnotateEntities have been removed / or added "
-                                     "manually. To fix, go into each project separately, or create new projects "
-                                     "and link to the ProjectGroup within ProjectAnnotateEntities page.")
+                update_projects_for_group(
+                    obj,
+                    annotators=list(obj.annotators.all()),
+                    admins=admins,
+                    cdb_search_filters=cdb_search_filters,
+                    tasks=tasks,
+                    relations=relations,
+                )
 
 
 class AnnotatedEntityAdmin(admin.ModelAdmin):

--- a/medcat-trainer/webapp/api/api/project_groups.py
+++ b/medcat-trainer/webapp/api/api/project_groups.py
@@ -1,0 +1,125 @@
+"""Helpers for creating annotation projects from a ProjectGroup.
+
+Django admin and the REST serializer both use these so a new group with
+``create_associated_projects=True`` yields one ProjectAnnotateEntities per annotator.
+"""
+from typing import Iterable, List, Optional, Sequence
+
+from django.contrib.auth.models import User
+
+from .models import ConceptDB, MetaTask, ProjectAnnotateEntities, ProjectGroup, Relation
+
+_PROJECT_COPY_FIELDS = (
+    'description',
+    'dataset',
+    'annotation_guideline_link',
+    'create_time',
+    'cuis',
+    'cuis_file',
+    'annotation_classification',
+    'project_locked',
+    'project_status',
+    'concept_db',
+    'vocab',
+    'model_pack',
+    'deid_model_annotation',
+    'use_model_service',
+    'model_service_url',
+    'require_entity_validation',
+    'train_model_on_submit',
+    'add_new_entities',
+    'restrict_concept_lookup',
+    'terminate_available',
+    'irrelevant_available',
+    'enable_entity_annotation_comments',
+)
+
+GROUP_PROJECTS_OUT_OF_SYNC_MESSAGE = (
+    "Attempting to update a ProjectGroup but one or more "
+    "of underlying ProjectAnnotateEntities have been removed / or added "
+    "manually. To fix, go into each project separately, or create new projects "
+    "and link to the ProjectGroup within ProjectAnnotateEntities page."
+)
+
+
+def populate_project_from_group(
+    proj: ProjectAnnotateEntities,
+    group: ProjectGroup,
+    annotator: User,
+    admins: Sequence[User],
+    cdb_search_filters: Sequence[ConceptDB],
+    tasks: Sequence[MetaTask],
+    relations: Sequence[Relation],
+) -> ProjectAnnotateEntities:
+    """Copy group settings onto a ProjectAnnotateEntities and assign members."""
+    proj.group = group
+    proj.name = f'{group.name} - {str(annotator)}'
+    for field in _PROJECT_COPY_FIELDS:
+        setattr(proj, field, getattr(group, field))
+
+    proj.save()
+    proj.cdb_search_filter.set(cdb_search_filters)
+    proj.members.set(admins)
+    proj.members.add(annotator)
+    proj.tasks.set(tasks)
+    proj.relations.set(relations)
+    proj.save()
+    return proj
+
+
+def create_projects_for_group(
+    group: ProjectGroup,
+    annotators: Optional[Iterable[User]] = None,
+    admins: Optional[Iterable[User]] = None,
+    cdb_search_filters: Optional[Iterable[ConceptDB]] = None,
+    tasks: Optional[Iterable[MetaTask]] = None,
+    relations: Optional[Iterable[Relation]] = None,
+) -> List[ProjectAnnotateEntities]:
+    """Create one annotation project per annotator from a newly saved group."""
+    annotators = list(annotators if annotators is not None else group.annotators.all())
+    admins = list(admins if admins is not None else group.administrators.all())
+    cdb_search_filters = list(
+        cdb_search_filters if cdb_search_filters is not None else group.cdb_search_filter.all()
+    )
+    tasks = list(tasks if tasks is not None else group.tasks.all())
+    relations = list(relations if relations is not None else group.relations.all())
+
+    created = []
+    for annotator in annotators:
+        created.append(
+            populate_project_from_group(
+                ProjectAnnotateEntities(),
+                group,
+                annotator,
+                admins,
+                cdb_search_filters,
+                tasks,
+                relations,
+            )
+        )
+    return created
+
+
+def update_projects_for_group(
+    group: ProjectGroup,
+    annotators: Sequence[User],
+    admins: Sequence[User],
+    cdb_search_filters: Sequence[ConceptDB],
+    tasks: Sequence[MetaTask],
+    relations: Sequence[Relation],
+) -> List[ProjectAnnotateEntities]:
+    """Re-apply group settings to existing associated projects.
+
+    Raises ValueError if the number of associated projects does not match annotators.
+    """
+    projs = list(ProjectAnnotateEntities.objects.filter(group=group))
+    if len(projs) != len(annotators):
+        raise ValueError(GROUP_PROJECTS_OUT_OF_SYNC_MESSAGE)
+    updated = []
+    for proj, annotator in zip(projs, annotators):
+        updated.append(
+            populate_project_from_group(
+                proj, group, annotator, admins, cdb_search_filters, tasks, relations
+            )
+        )
+    return updated

--- a/medcat-trainer/webapp/api/api/serializers.py
+++ b/medcat-trainer/webapp/api/api/serializers.py
@@ -6,6 +6,7 @@ from rest_framework.fields import FileField
 from rest_framework.serializers import Serializer
 
 from .models import *
+from .project_groups import create_projects_for_group
 from rest_framework import serializers
 
 
@@ -107,9 +108,35 @@ class ProjectAnnotateEntitiesSerializer(serializers.ModelSerializer):
 
 
 class ProjectGroupSerializer(serializers.ModelSerializer):
+    administrators = serializers.PrimaryKeyRelatedField(
+        many=True, queryset=User.objects.all(), required=False, allow_empty=True
+    )
+    annotators = serializers.PrimaryKeyRelatedField(
+        many=True, queryset=User.objects.all(), required=False, allow_empty=True
+    )
+
     class Meta:
         model = ProjectGroup
         fields = '__all__'
+
+    def validate(self, attrs):
+        if self.instance is None:
+            create_associated = attrs.get('create_associated_projects', True)
+            annotators = attrs.get('annotators') or []
+            if create_associated and not annotators:
+                raise serializers.ValidationError({
+                    'annotators': 'Select at least one annotator to create associated projects.'
+                })
+        return attrs
+
+    def create(self, validated_data):
+        group = super().create(validated_data)
+        request = self.context.get('request')
+        if request is not None and getattr(request.user, 'is_authenticated', False):
+            group.administrators.add(request.user)
+        if group.create_associated_projects:
+            create_projects_for_group(group)
+        return group
 
     def to_representation(self, instance):
         # enrich with other fields? last_modified etc.?

--- a/medcat-trainer/webapp/api/api/tests/test_project_groups.py
+++ b/medcat-trainer/webapp/api/api/tests/test_project_groups.py
@@ -1,0 +1,76 @@
+"""Unit tests for creating annotation projects from a ProjectGroup."""
+
+from django.test import TestCase, override_settings
+
+from ..models import ConceptDB, ProjectAnnotateEntities, ProjectGroup, Vocabulary
+from ..project_groups import (
+    GROUP_PROJECTS_OUT_OF_SYNC_MESSAGE,
+    create_projects_for_group,
+    populate_project_from_group,
+    update_projects_for_group,
+)
+from ._helpers import create_dataset, create_user
+
+
+@override_settings(MEDIA_ROOT='/tmp/mct-tests-project-groups')
+class CreateProjectsForGroupTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cdb = ConceptDB(name='pgh_cdb', cdb_file='pgh_cdb.dat')
+        cdb.save(skip_load=True)
+        vocab = Vocabulary(name='pgh_vocab', vocab_file='pgh_vocab.dat')
+        vocab.save(skip_load=True)
+        cls.dataset = create_dataset(name='pgh_ds', file_name='pgh_ds.csv')
+        cls.cdb = cdb
+        cls.vocab = vocab
+
+    def _group(self, name='pgh-group'):
+        return ProjectGroup.objects.create(
+            name=name,
+            dataset=self.dataset,
+            concept_db=self.cdb,
+            vocab=self.vocab,
+            cuis='',
+            description='shared',
+        )
+
+    def test_populate_copies_group_settings_and_members(self):
+        admin = create_user(username='pgh-admin')
+        annotator = create_user(username='pgh-ann')
+        group = self._group()
+        proj = populate_project_from_group(
+            ProjectAnnotateEntities(),
+            group,
+            annotator,
+            [admin],
+            [self.cdb],
+            [],
+            [],
+        )
+        self.assertEqual(proj.name, 'pgh-group - pgh-ann')
+        self.assertEqual(proj.description, 'shared')
+        self.assertEqual(proj.group_id, group.id)
+        self.assertEqual(proj.dataset_id, self.dataset.id)
+        members = set(proj.members.all())
+        self.assertEqual(members, {admin, annotator})
+        self.assertEqual(list(proj.cdb_search_filter.all()), [self.cdb])
+
+    def test_create_projects_for_group_uses_group_m2m_when_lists_omitted(self):
+        admin = create_user(username='pgh-admin2')
+        annotator = create_user(username='pgh-ann2')
+        group = self._group(name='pgh-m2m')
+        group.administrators.add(admin)
+        group.annotators.add(annotator)
+        group.cdb_search_filter.add(self.cdb)
+
+        created = create_projects_for_group(group)
+        self.assertEqual(len(created), 1)
+        self.assertEqual(created[0].name, 'pgh-m2m - pgh-ann2')
+        self.assertIn(admin, created[0].members.all())
+        self.assertIn(annotator, created[0].members.all())
+
+    def test_update_raises_when_project_count_does_not_match_annotators(self):
+        group = self._group(name='pgh-sync')
+        annotator = create_user(username='pgh-ann3')
+        with self.assertRaisesMessage(ValueError, GROUP_PROJECTS_OUT_OF_SYNC_MESSAGE):
+            update_projects_for_group(group, [annotator], [], [], [], [])

--- a/medcat-trainer/webapp/api/api/tests/test_serializers.py
+++ b/medcat-trainer/webapp/api/api/tests/test_serializers.py
@@ -186,6 +186,56 @@ class ProjectGroupSerializerTests(TestCase):
         data = ProjectGroupSerializer(group).data
         self.assertIsNotNone(data['last_modified'])
 
+    def _group_payload(self, **overrides):
+        data = {
+            'name': 'new-group',
+            'description': 'group desc',
+            'dataset': self.dataset.id,
+            'concept_db': self.cdb.id,
+            'vocab': self.vocab.id,
+            'cuis': '',
+            'create_associated_projects': True,
+            'annotators': [],
+            'administrators': [],
+        }
+        data.update(overrides)
+        return data
+
+    def test_create_requires_annotators_when_creating_associated_projects(self):
+        serializer = ProjectGroupSerializer(data=self._group_payload())
+        self.assertFalse(serializer.is_valid())
+        self.assertIn('annotators', serializer.errors)
+
+    def test_create_spawns_one_project_per_annotator(self):
+        creator = User.objects.create_user(username='pg-creator', password='pw')
+        a1 = User.objects.create_user(username='ann-one', password='pw')
+        a2 = User.objects.create_user(username='ann-two', password='pw')
+
+        serializer = ProjectGroupSerializer(
+            data=self._group_payload(annotators=[a1.id, a2.id]),
+            context={'request': type('Req', (), {'user': creator})()},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        group = serializer.save()
+
+        projects = list(ProjectAnnotateEntities.objects.filter(group=group).order_by('name'))
+        self.assertEqual(len(projects), 2)
+        self.assertEqual(projects[0].name, 'new-group - ann-one')
+        self.assertEqual(projects[1].name, 'new-group - ann-two')
+        self.assertEqual(projects[0].description, 'group desc')
+        self.assertEqual(projects[0].dataset_id, self.dataset.id)
+        self.assertIn(a1, projects[0].members.all())
+        self.assertIn(creator, projects[0].members.all())
+        self.assertIn(creator, group.administrators.all())
+
+    def test_create_skips_associated_projects_when_disabled(self):
+        serializer = ProjectGroupSerializer(
+            data=self._group_payload(create_associated_projects=False),
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        group = serializer.save()
+        self.assertEqual(ProjectAnnotateEntities.objects.filter(group=group).count(), 0)
+
 
 @override_settings(MEDIA_ROOT='/tmp/mct-tests-serializers')
 class DatasetSerializerTests(TestCase):

--- a/medcat-trainer/webapp/api/api/tests/test_views.py
+++ b/medcat-trainer/webapp/api/api/tests/test_views.py
@@ -381,3 +381,64 @@ class DownloadAnnosTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         # Response is a streaming JSON document
         self.assertIn('Content-Disposition', resp)
+
+
+@override_settings(MEDIA_ROOT='/tmp/mct-tests-views')
+class ProjectGroupCreateTests(TestCase):
+    def setUp(self):
+        self.creator = create_user(username='pg-api-creator')
+        self.annotator = create_user(username='pg-api-ann')
+        self.client = _auth_client(self.creator)
+        cdb = ConceptDB(name='pg-api-cdb', cdb_file='pg-api-cdb.dat')
+        cdb.save(skip_load=True)
+        vocab = Vocabulary(name='pg-api-vocab', vocab_file='pg-api-vocab.dat')
+        vocab.save(skip_load=True)
+        self.dataset = create_dataset(name='pg-api-ds', file_name='pg-api-ds.csv')
+        self.cdb = cdb
+        self.vocab = vocab
+
+    def test_post_creates_group_and_associated_projects(self):
+        resp = self.client.post(
+            '/api/project-groups/',
+            {
+                'name': 'api-group',
+                'description': 'from api',
+                'dataset': self.dataset.id,
+                'concept_db': self.cdb.id,
+                'vocab': self.vocab.id,
+                'cuis': '',
+                'annotators': [self.annotator.id],
+                'create_associated_projects': True,
+            },
+            format='json',
+        )
+        self.assertEqual(resp.status_code, 201, msg=resp.content)
+        self.assertEqual(resp.json()['name'], 'api-group')
+        projects = ProjectAnnotateEntities.objects.filter(group_id=resp.json()['id'])
+        self.assertEqual(projects.count(), 1)
+        project = projects.get()
+        self.assertEqual(project.name, 'api-group - pg-api-ann')
+        self.assertIn(self.annotator, project.members.all())
+        self.assertIn(self.creator, project.members.all())
+
+    def test_post_without_annotators_returns_400(self):
+        resp = self.client.post(
+            '/api/project-groups/',
+            {
+                'name': 'api-group-empty',
+                'dataset': self.dataset.id,
+                'concept_db': self.cdb.id,
+                'vocab': self.vocab.id,
+                'cuis': '',
+                'create_associated_projects': True,
+            },
+            format='json',
+        )
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn('annotators', resp.json())
+
+    def test_anonymous_cannot_create_group(self):
+        client = APIClient()
+        resp = client.post('/api/project-groups/', {'name': 'nope'}, format='json')
+        self.assertIn(resp.status_code, (401, 403))
+

--- a/medcat-trainer/webapp/frontend/src/components/admin/ProjectsList.vue
+++ b/medcat-trainer/webapp/frontend/src/components/admin/ProjectsList.vue
@@ -163,11 +163,17 @@
 
     <div v-else class="empty-state">
       <h4>No Projects Yet</h4>
-      <p>You don't have any projects yet. Create one to get started!</p>
-      <button class="btn btn-primary btn-create-empty" @click="$emit('create-project')">
-        <font-awesome-icon icon="plus"></font-awesome-icon>
-        <span>Create Your First Project</span>
-      </button>
+      <p>You don't have any projects yet. Create a project or a project group to get started.</p>
+      <div class="empty-state-actions">
+        <button class="btn btn-primary btn-create-empty" @click="$emit('create-project')">
+          <font-awesome-icon icon="plus"></font-awesome-icon>
+          <span>Create Your First Project</span>
+        </button>
+        <button class="btn btn-outline-primary btn-create-empty" @click="$emit('create-project-group')">
+          <font-awesome-icon icon="layer-group"></font-awesome-icon>
+          <span>Create a Project Group</span>
+        </button>
+      </div>
     </div>
   </div>
 </template>
@@ -192,7 +198,7 @@ export default {
       required: true
     }
   },
-  emits: ['select-project', 'clone-project', 'confirm-reset', 'confirm-delete', 'create-project'],
+  emits: ['select-project', 'clone-project', 'confirm-reset', 'confirm-delete', 'create-project', 'create-project-group'],
   data() {
     return {
       searchQuery: '',
@@ -366,6 +372,13 @@ export default {
   .empty-state-filtered {
     padding: 40px 20px;
     text-align: center;
+  }
+
+  .empty-state-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 12px;
   }
 }
 </style>

--- a/medcat-trainer/webapp/frontend/src/components/common/ProjectList.vue
+++ b/medcat-trainer/webapp/frontend/src/components/common/ProjectList.vue
@@ -792,7 +792,7 @@ export default {
 }
 
 .project-table {
-  height: calc(100% - 30px);
+  height: 100%;
   padding: 10px 0;
   width: 96%;
   max-width: 96%;

--- a/medcat-trainer/webapp/frontend/src/tests/components/ProjectsList.spec.ts
+++ b/medcat-trainer/webapp/frontend/src/tests/components/ProjectsList.spec.ts
@@ -117,4 +117,12 @@ describe('ProjectsList.vue', () => {
     await wrapper.find('.btn-create-empty').trigger('click')
     expect(wrapper.emitted('create-project')).toBeTruthy()
   })
+
+  it('emits create-project-group from empty-state button', async () => {
+    const wrapper = mountList({ projects: [] })
+    const buttons = wrapper.findAll('.btn-create-empty')
+    expect(buttons).toHaveLength(2)
+    await buttons[1].trigger('click')
+    expect(wrapper.emitted('create-project-group')).toBeTruthy()
+  })
 })

--- a/medcat-trainer/webapp/frontend/src/tests/views/Home.spec.ts
+++ b/medcat-trainer/webapp/frontend/src/tests/views/Home.spec.ts
@@ -92,7 +92,7 @@ describe('Home.vue', () => {
           $http: { get: mockGet },
           $cookies: mockCookies
         },
-        stubs: ['login', 'modal', 'project-list', 'v-data-table', 'transition', 'router-link', 'router-view']
+        stubs: ['login', 'modal', 'project-list', 'v-data-table', 'transition', 'router-link', 'router-view', 'font-awesome-icon', 'plugin-slot']
       }
     });
 
@@ -133,7 +133,7 @@ describe('Home.vue', () => {
           $http: { get: mockGet },
           $cookies: mockCookies
         },
-        stubs: ['login', 'modal', 'project-list', 'v-data-table', 'transition', 'router-link', 'router-view']
+        stubs: ['login', 'modal', 'project-list', 'v-data-table', 'transition', 'router-link', 'router-view', 'font-awesome-icon', 'plugin-slot']
       }
     });
 
@@ -171,7 +171,7 @@ describe('Home.vue', () => {
           $http: { get: mockGet },
           $cookies: mockCookies
         },
-        stubs: ['login', 'modal', 'project-list', 'v-data-table', 'transition', 'router-link', 'router-view']
+        stubs: ['login', 'modal', 'project-list', 'v-data-table', 'transition', 'router-link', 'router-view', 'font-awesome-icon', 'plugin-slot']
       }
     });
 
@@ -181,5 +181,58 @@ describe('Home.vue', () => {
     // Cookie wipe is owned by httpAuth on 401; Home must not double-clear.
     expect(mockCookies.remove).not.toHaveBeenCalled();
     expect(wrapper.vm.loginSuccessful).toBe(false);
+  });
+
+  it('shows Projects / Project Groups tabs for admins and switches the list', async () => {
+    const mockGet = vi.fn((url: string) => {
+      if (url === '/api/behind-rp/') {
+        return Promise.resolve({ data: true });
+      }
+      if (url === '/api/project-annotate-entities/') {
+        return Promise.resolve({ data: { results: [testProjectsResponse], next: null } });
+      }
+      if (url.startsWith('/api/concept-db-search-index-created/')) {
+        return Promise.resolve({ data: { results: [] } });
+      }
+      if (url === '/api/project-progress/?projects=1') {
+        return Promise.resolve({ data: testProjectProgress });
+      }
+      if (url.startsWith('/api/project-groups/')) {
+        return Promise.resolve({ data: { results: [] } });
+      }
+      return Promise.resolve({});
+    });
+    const mockCookies = {
+      get: vi.fn((key: string) => {
+        if (key === 'api-token') return 'token';
+        if (key === 'admin') return 'true';
+        return null;
+      }),
+      remove: vi.fn()
+    };
+
+    const wrapper = mount(Home, {
+      global: {
+        plugins: [router],
+        mocks: {
+          $http: { get: mockGet },
+          $cookies: mockCookies
+        },
+        stubs: ['login', 'modal', 'project-list', 'v-data-table', 'transition', 'router-link', 'router-view', 'font-awesome-icon', 'plugin-slot']
+      }
+    });
+
+    await router.isReady();
+    await flushPromises();
+
+    const tabs = wrapper.findAll('.tab-button')
+    expect(tabs).toHaveLength(2)
+    expect(tabs[0].text()).toContain('Projects')
+    expect(tabs[1].text()).toContain('Project Groups')
+    expect(tabs[0].classes()).toContain('active')
+
+    await tabs[1].trigger('click')
+    expect(wrapper.vm.projectGroupView).toBe(true)
+    expect(tabs[1].classes()).toContain('active')
   });
 });

--- a/medcat-trainer/webapp/frontend/src/tests/views/ProjectAdmin.spec.ts
+++ b/medcat-trainer/webapp/frontend/src/tests/views/ProjectAdmin.spec.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import ProjectAdmin from '@/views/ProjectAdmin.vue'
+
+const emptyList = { data: { results: [] } }
+
+function mountAdmin(http: { get: ReturnType<typeof vi.fn>; post: ReturnType<typeof vi.fn>; put?: ReturnType<typeof vi.fn> }) {
+  return mount(ProjectAdmin, {
+    global: {
+      mocks: {
+        $http: http,
+        $toast: { success: vi.fn(), error: vi.fn() }
+      },
+      stubs: {
+        'font-awesome-icon': true,
+        'v-progress-circular': true,
+        'plugin-slot': true,
+        modal: true,
+        'concept-picker': true,
+        'projects-list': true,
+        'model-packs-list': true,
+        'model-pack-form': true,
+        'datasets-list': true,
+        'dataset-form': true,
+        'users-list': true,
+        'user-form': true
+      }
+    }
+  })
+}
+
+describe('ProjectAdmin.vue project group create', () => {
+  let mockGet: ReturnType<typeof vi.fn>
+  let mockPost: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockGet = vi.fn((url: string) => {
+      if (url === '/api/project-admin/projects/') {
+        return Promise.resolve({ data: [] })
+      }
+      if (url === '/api/users/') {
+        return Promise.resolve({
+          data: { results: [{ id: 2, username: 'annotator' }, { id: 3, username: 'admin-user' }] }
+        })
+      }
+      if (url === '/api/datasets/') {
+        return Promise.resolve({ data: { results: [{ id: 10, name: 'Notes' }] } })
+      }
+      if (url === '/api/modelpacks/') {
+        return Promise.resolve({
+          data: { results: [{ id: 7, name: 'SNOMED', concept_db: 4 }] }
+        })
+      }
+      if (url.startsWith('/api/concept-db-search-index-created/')) {
+        return Promise.resolve({ data: { results: { 4: true } } })
+      }
+      return Promise.resolve(emptyList)
+    })
+    mockPost = vi.fn().mockResolvedValue({ data: { id: 99, name: 'Group A' } })
+  })
+
+  it('opens the form in group mode from the header toolbar', async () => {
+    const wrapper = mountAdmin({ get: mockGet, post: mockPost })
+    await flushPromises()
+    await wrapper.find('.btn-create').trigger('click')
+    const groupTab = wrapper.findAll('.form-type-btn').find(b => b.text().includes('Project Group'))
+    expect(groupTab).toBeTruthy()
+    await groupTab!.trigger('click')
+    expect(wrapper.text()).toContain('Annotators')
+    expect(wrapper.text()).toContain('Administrators')
+    expect(wrapper.find('.form-toolbar').exists()).toBe(true)
+  })
+
+  it('posts to /api/project-groups/ when saving a new group', async () => {
+    const wrapper = mountAdmin({ get: mockGet, post: mockPost })
+    await flushPromises()
+    const vm = wrapper.vm as unknown as {
+      openCreateForm: (mode: string) => void
+      formData: Record<string, unknown>
+      saveProject: () => Promise<void>
+    }
+    vm.openCreateForm('group')
+    vm.formData.name = 'Group A'
+    vm.formData.dataset = 10
+    vm.formData.model_pack = 7
+    vm.formData.annotators = [2]
+    await vm.saveProject()
+    await flushPromises()
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/project-groups/',
+      expect.objectContaining({
+        name: 'Group A',
+        dataset: 10,
+        model_pack: 7,
+        annotators: [2],
+        create_associated_projects: true
+      })
+    )
+  })
+
+  it('does not post a group when annotators are missing', async () => {
+    const wrapper = mountAdmin({ get: mockGet, post: mockPost })
+    await flushPromises()
+    const vm = wrapper.vm as unknown as {
+      openCreateForm: (mode: string) => void
+      formData: Record<string, unknown>
+      saveProject: () => Promise<void>
+      validationErrors: Record<string, string>
+    }
+    vm.openCreateForm('group')
+    vm.formData.name = 'Group A'
+    vm.formData.dataset = 10
+    vm.formData.model_pack = 7
+    await wrapper.vm.$nextTick()
+    await vm.saveProject()
+    expect(mockPost).not.toHaveBeenCalled()
+    expect(vm.validationErrors.annotators).toBeTruthy()
+  })
+})

--- a/medcat-trainer/webapp/frontend/src/views/Home.vue
+++ b/medcat-trainer/webapp/frontend/src/views/Home.vue
@@ -1,45 +1,53 @@
 <template>
-  <div class="full-height">
+  <div class="full-height home-page">
     <login v-if="!loginSuccessful" @login:success="loggedIn()"></login>
     <transition name="alert"><div class="alert alert-danger" v-if="routeAlert" role="alert">{{routeAlert}}</div></transition>
-    <div class="view-bar" v-if="isAdmin || loginSuccessful">
-      <div class="view-bar-left">
-        <button v-if="isAdmin" class="btn btn-outline-primary" @click="projectGroupView = !projectGroupView">
-          <span v-if="projectGroupView">Single Projects</span>
-          <span v-if="!projectGroupView">Project Groups</span>
-        </button>
-      </div>
-      <div class="view-bar-right">
-      </div>
+    <div v-if="isAdmin && loginSuccessful" class="home-tabs">
+      <button
+        type="button"
+        class="tab-button"
+        :class="{ active: !projectGroupView }"
+        @click="projectGroupView = false">
+        <font-awesome-icon icon="folder"></font-awesome-icon>
+        Projects
+      </button>
+      <button
+        type="button"
+        class="tab-button"
+        :class="{ active: projectGroupView }"
+        @click="projectGroupView = true">
+        <font-awesome-icon icon="layer-group"></font-awesome-icon>
+        Project Groups
+      </button>
     </div>
-    <div v-if="projectGroupView" class="full-height project-group-table">
-      <v-data-table id="projectGroupTable" :items="projectGroups.items"
-                    :headers="projectGroups.headers"
-                    :hover="true"
-                    v-if="!loadingProjects"
-                    color="primary"
-                    @click:row="selectProjectGroup"
-                    hide-default-footer
-                    :items-per-page="-1">
-        <template v-slot:item.last_modified="{ item }">
-          {{new Date(item.last_modified).toLocaleString()}}
-        </template>
-      </v-data-table>
-      <modal v-if="selectedProjectGroup" :closable="true" @modal:close="selectedProjectGroup = null" class="summary-modal">
-        <template #header>
-          <h3>Project Group: {{selectedProjectGroup.name}}</h3>
-          <br>
-          <p>{{selectedProjectGroup.description}}</p>
-        </template>
-        <template #body>
-          <project-list :project-items="selectedProjectGroup.items" :is-admin="isAdmin"
-                        :cdb-search-index-status="cdbSearchIndexStatus"></project-list>
-        </template>
-      </modal>
+    <div class="home-content">
+      <div v-if="projectGroupView" class="full-height project-group-table">
+        <v-data-table id="projectGroupTable" :items="projectGroups.items"
+                      :headers="projectGroups.headers"
+                      :hover="true"
+                      v-if="!loadingProjects"
+                      color="primary"
+                      @click:row="selectProjectGroup"
+                      hide-default-footer
+                      :items-per-page="-1">
+          <template v-slot:item.last_modified="{ item }">
+            {{new Date(item.last_modified).toLocaleString()}}
+          </template>
+        </v-data-table>
+        <modal v-if="selectedProjectGroup" :closable="true" @modal:close="selectedProjectGroup = null" class="summary-modal">
+          <template #header>
+            <h3>Project Group: {{selectedProjectGroup.name}}</h3>
+          </template>
+          <template #body>
+            <project-list :project-items="selectedProjectGroup.items" :is-admin="isAdmin"
+                          :cdb-search-index-status="cdbSearchIndexStatus"></project-list>
+          </template>
+        </modal>
+      </div>
+      <project-list v-if="!projectGroupView" :project-items="projects.items" :is-admin="isAdmin"
+                    :cdb-search-index-status="cdbSearchIndexStatus"></project-list>
+      <plugin-slot name="home:after-projects" />
     </div>
-    <project-list v-if="!projectGroupView" :project-items="projects.items" :is-admin="isAdmin"
-                  :cdb-search-index-status="cdbSearchIndexStatus"></project-list>
-    <plugin-slot name="home:after-projects" />
   </div>
 
 </template>
@@ -192,39 +200,65 @@ export default {
 }
 </script>
 
-<style lang="scss">
-h3 {
-  margin: 10%
+<style scoped lang="scss">
+@import '@/styles/variables.scss';
+
+.home-page {
+  display: flex;
+  flex-direction: column;
 }
 
-.view-bar {
-  height: 30px;
-  padding: 5px 0;
-  width: 95%;
-  margin: auto;
+.home-tabs {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
+  gap: 8px;
+  width: 96%;
+  margin: 8px auto 0;
+  border-bottom: 2px solid var(--color-border);
+  padding-bottom: 0;
+  flex-shrink: 0;
+}
 
-  .view-bar-left, .view-bar-right {
-    display: flex;
-    gap: 10px;
+.tab-button {
+  padding: 10px 20px;
+  background: transparent;
+  border: none;
+  border-bottom: 3px solid transparent;
+  cursor: pointer;
+  font-size: 0.95rem;
+  font-weight: 500;
+  color: var(--color-text-secondary);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: -2px;
+
+  &:hover {
+    color: var(--color-primary, $primary);
+    background: rgba(0, 0, 0, 0.02);
+  }
+
+  &.active {
+    color: var(--color-primary, $primary);
+    border-bottom-color: var(--color-primary, $primary);
+    font-weight: 600;
   }
 }
 
-.project-group-table {
-  height: calc(100% - 30px);
-  padding: 10px 0;
-  width: 95%;
-  margin: auto;
+.home-content {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
 }
 
+.project-group-table {
+  height: 100%;
+  padding: 10px 0;
+  width: 96%;
+  margin: 0 auto;
+}
 
 .home-title {
   font-size: 23px;
   padding: 30px 0;
 }
-
-
-
 </style>

--- a/medcat-trainer/webapp/frontend/src/views/ProjectAdmin.vue
+++ b/medcat-trainer/webapp/frontend/src/views/ProjectAdmin.vue
@@ -7,9 +7,9 @@
           <p class="subtitle">Manage your annotation projects</p>
         </div>
         <div class="header-actions">
-          <button v-if="activeTab === 'projects'" class="btn btn-primary btn-create" @click="showCreateForm = true">
+          <button v-if="activeTab === 'projects'" class="btn btn-primary btn-create" @click="openCreateForm('project')">
             <font-awesome-icon icon="plus"></font-awesome-icon>
-            <span>Create New Project</span>
+            <span>Create</span>
           </button>
           <button v-if="activeTab === 'modelpacks'" class="btn btn-primary btn-create" @click="showModelPackForm = true; editingModelPack = null">
             <font-awesome-icon icon="plus"></font-awesome-icon>
@@ -77,7 +77,8 @@
         @clone-project="cloneProject"
         @confirm-reset="confirmReset"
         @confirm-delete="confirmDelete"
-        @create-project="showCreateForm = true"
+        @create-project="openCreateForm('project')"
+        @create-project-group="openCreateForm('group')"
       />
 
       <!-- Project Form View (replaces list) -->
@@ -87,13 +88,48 @@
             <font-awesome-icon icon="arrow-left"></font-awesome-icon>
             <span>Back</span>
           </button>
-          <h3>{{ editingProject ? 'Edit Project' : 'Create New Project' }}</h3>
+          <div
+            v-if="!editingProject"
+            class="form-type-switch"
+            role="tablist"
+            aria-label="What to create">
+            <button
+              type="button"
+              role="tab"
+              class="form-type-btn"
+              :class="{ active: createMode === 'project' }"
+              :aria-selected="createMode === 'project'"
+              @click="createMode = 'project'">
+              <font-awesome-icon icon="folder"></font-awesome-icon>
+              <span>Project</span>
+            </button>
+            <button
+              type="button"
+              role="tab"
+              class="form-type-btn"
+              :class="{ active: createMode === 'group' }"
+              :aria-selected="createMode === 'group'"
+              @click="createMode = 'group'">
+              <font-awesome-icon icon="layer-group"></font-awesome-icon>
+              <span>Project Group</span>
+            </button>
+          </div>
+          <h3 v-else>{{ formTitle }}</h3>
           <div class="form-header-actions">
             <button type="submit" form="project-admin-form" class="btn btn-primary" :disabled="saving">
               <font-awesome-icon v-if="saving" icon="spinner" spin></font-awesome-icon>
-              <span>{{ saving ? 'Saving...' : 'Save Project' }}</span>
+              <span>{{ saving ? 'Saving...' : saveButtonLabel }}</span>
             </button>
           </div>
+        </div>
+        <div v-if="isCreatingGroup" class="form-toolbar">
+          <p class="form-toolbar-hint">
+            Shared settings across annotators. Used for agreement metrics and adjudication.
+          </p>
+          <label class="form-toolbar-check">
+            <input v-model="formData.create_associated_projects" type="checkbox" class="checkbox-input" />
+            <span>Create an annotation project for each annotator</span>
+          </label>
         </div>
         <div class="form-content">
           <form id="project-admin-form" @submit.prevent="saveProject" class="project-form">
@@ -385,8 +421,33 @@
             </div>
 
             <div class="form-section">
-              <h4>Members</h4>
-              <div class="form-group">
+              <h4>{{ isCreatingGroup ? 'Group Members' : 'Members' }}</h4>
+              <template v-if="isCreatingGroup">
+                <div class="form-group">
+                  <label>Administrators</label>
+                  <select v-model="formData.administrators" multiple class="form-control">
+                    <option v-for="user in users" :key="'admin-' + user.id" :value="user.id">{{ user.username }}</option>
+                  </select>
+                  <small class="form-text text-muted">Users who can see and manage all projects in this group. You are added automatically. Hold Ctrl/Cmd to select multiple.</small>
+                </div>
+                <div class="form-group">
+                  <label>Annotators <span v-if="formData.create_associated_projects">*</span></label>
+                  <select
+                    v-model="formData.annotators"
+                    multiple
+                    name="annotators"
+                    data-field="annotators"
+                    class="form-control"
+                    :class="{ 'is-invalid': validationErrors.annotators }"
+                    @change="clearValidationError('annotators')"
+                  >
+                    <option v-for="user in users" :key="'annotator-' + user.id" :value="user.id">{{ user.username }}</option>
+                  </select>
+                  <small v-if="validationErrors.annotators" class="form-text text-danger">{{ validationErrors.annotators }}</small>
+                  <small v-else class="form-text text-muted">Hold Ctrl/Cmd to select multiple. One annotation project is created per annotator.</small>
+                </div>
+              </template>
+              <div v-else class="form-group">
                 <label>Project Members</label>
                 <select v-model="formData.members" multiple class="form-control">
                   <option v-for="user in users" :key="user.id" :value="user.id">{{ user.username }}</option>
@@ -602,6 +663,7 @@ export default {
       modelPacks: [],
       users: [],
       showCreateForm: false,
+      createMode: 'project',
       editingProject: null,
       projectToDelete: null,
       projectToReset: null,
@@ -648,7 +710,10 @@ export default {
         enable_entity_annotation_comments: false,
         cuis: '',
         cuis_file: null,
-        members: []
+        members: [],
+        administrators: [],
+        annotators: [],
+        create_associated_projects: true
       },
       validationErrors: {},
       tableHeaders: [
@@ -662,6 +727,18 @@ export default {
   },
   created() {
     this.loadData()
+  },
+  computed: {
+    isCreatingGroup() {
+      return !this.editingProject && this.createMode === 'group'
+    },
+    formTitle() {
+      if (this.editingProject) return 'Edit Project'
+      return this.isCreatingGroup ? 'Create Project Group' : 'Create Annotation Project'
+    },
+    saveButtonLabel() {
+      return this.isCreatingGroup ? 'Save Project Group' : 'Save Project'
+    }
   },
   methods: {
     async loadData() {
@@ -736,6 +813,10 @@ export default {
       // v-data-table click:row passes (event, { item })
       this.editProject(item)
     },
+    openCreateForm(mode = 'project') {
+      this.createMode = mode === 'group' ? 'group' : 'project'
+      this.showCreateForm = true
+    },
     editProject(project) {
       this.editingProject = project
       this.formData = {
@@ -777,6 +858,7 @@ export default {
     closeForm() {
       this.showCreateForm = false
       this.editingProject = null
+      this.createMode = 'project'
       this.useBackupOption = false
       this.useDefaultGuideline = false
       this.validationErrors = {}
@@ -815,7 +897,10 @@ export default {
         enable_entity_annotation_comments: false,
         cuis: '',
         cuis_file: null,
-        members: []
+        members: [],
+        administrators: [],
+        annotators: [],
+        create_associated_projects: true
       }
       this.useBackupOption = false
       this.useDefaultGuideline = false
@@ -873,6 +958,28 @@ export default {
       }
       return null
     },
+    toIntList(values) {
+      if (!Array.isArray(values)) return []
+      return values
+        .map(val => {
+          if (val === null || val === undefined || val === '') return null
+          const numVal = typeof val === 'string' ? parseInt(val, 10) : Number(val)
+          return (!isNaN(numVal) && isFinite(numVal)) ? numVal : null
+        })
+        .filter(val => val !== null)
+    },
+    resolveConceptDbIdForFilter() {
+      if (this.formData.model_pack) {
+        const modelPack = this.modelPacks.find(mp => mp.id === this.formData.model_pack)
+        if (modelPack?.concept_db != null) {
+          return typeof modelPack.concept_db === 'object' ? modelPack.concept_db.id : modelPack.concept_db
+        }
+      }
+      if (this.formData.concept_db) {
+        return this.formData.concept_db
+      }
+      return null
+    },
     handleInvalid(event) {
       // Prevent browser's default validation message popup
       event.preventDefault()
@@ -906,6 +1013,13 @@ export default {
       if (!this.formData.dataset) {
         this.validationErrors.dataset = 'Dataset is required'
         isValid = false
+      }
+
+      if (this.isCreatingGroup && this.formData.create_associated_projects) {
+        if (!this.formData.annotators || this.formData.annotators.length === 0) {
+          this.validationErrors.annotators = 'Select at least one annotator to create associated projects'
+          isValid = false
+        }
       }
 
       // Model configuration validation
@@ -964,6 +1078,17 @@ export default {
           this.formData.vocab = null
         }
 
+        if (this.isCreatingGroup) {
+          const newCdbId = await this.saveProjectGroup()
+          this.$toast?.success('Project group created successfully')
+          if (newCdbId) {
+            await this.ensureConceptsImported(newCdbId)
+          }
+          this.closeForm()
+          await this.fetchProjects()
+          return
+        }
+
         // Prepare data payload - convert members to integers
         const payload = { ...this.formData }
 
@@ -989,29 +1114,22 @@ export default {
 
         // Ensure members are integers
         if (Array.isArray(payload.members)) {
-          payload.members = payload.members
-            .map(val => {
-              if (val === null || val === undefined || val === '') return null
-              const numVal = typeof val === 'string' ? parseInt(val, 10) : Number(val)
-              return (!isNaN(numVal) && isFinite(numVal)) ? numVal : null
-            })
-            .filter(val => val !== null)
+          payload.members = this.toIntList(payload.members)
         } else {
           payload.members = []
         }
 
         // Ensure cdb_search_filter are integers
         if (Array.isArray(payload.cdb_search_filter)) {
-          payload.cdb_search_filter = payload.cdb_search_filter
-            .map(val => {
-              if (val === null || val === undefined || val === '') return null
-              const numVal = typeof val === 'string' ? parseInt(val, 10) : Number(val)
-              return (!isNaN(numVal) && isFinite(numVal)) ? numVal : null
-            })
-            .filter(val => val !== null)
+          payload.cdb_search_filter = this.toIntList(payload.cdb_search_filter)
         } else {
           payload.cdb_search_filter = []
         }
+
+        // Group-only fields are not valid on a single project
+        delete payload.administrators
+        delete payload.annotators
+        delete payload.create_associated_projects
 
         // Remove cuis_file from JSON payload (file uploads would need separate handling if needed)
         delete payload.cuis_file
@@ -1046,7 +1164,7 @@ export default {
       } catch (error) {
         console.error('Error saving project:', error)
         console.error('Error response:', error.response?.data)
-        let errorMsg = 'Failed to save project'
+        let errorMsg = this.isCreatingGroup ? 'Failed to save project group' : 'Failed to save project'
         if (error.response?.data) {
           if (typeof error.response.data === 'string') {
             errorMsg = error.response.data
@@ -1069,6 +1187,18 @@ export default {
       } finally {
         this.saving = false
       }
+    },
+    async saveProjectGroup() {
+      const payload = { ...this.formData }
+      const conceptDbIdForFilter = this.resolveConceptDbIdForFilter()
+      payload.cdb_search_filter = conceptDbIdForFilter != null ? this.toIntList([conceptDbIdForFilter]) : []
+      payload.administrators = this.toIntList(payload.administrators)
+      payload.annotators = this.toIntList(payload.annotators)
+      payload.create_associated_projects = !!payload.create_associated_projects
+      delete payload.members
+      delete payload.cuis_file
+      await this.$http.post('/api/project-groups/', payload)
+      return conceptDbIdForFilter
     },
     async ensureConceptsImported(cdbId) {
       // Mirrors the "Concepts Imported" check from ProjectList.vue: ask Solr whether the
@@ -1374,6 +1504,11 @@ export default {
         delete this.validationErrors.dataset
       }
     },
+    'formData.annotators'() {
+      if (this.validationErrors.annotators) {
+        delete this.validationErrors.annotators
+      }
+    },
     'formData.model_service_url'() {
       if (this.validationErrors.model_service_url) {
         delete this.validationErrors.model_service_url
@@ -1564,6 +1699,45 @@ export default {
       }
     }
 
+    .form-type-switch {
+      display: flex;
+      flex: 1;
+      min-width: 0;
+      max-width: 420px;
+      margin: 0 auto;
+      padding: 3px;
+      background: rgba(255, 255, 255, 0.16);
+      border: 1px solid rgba(255, 255, 255, 0.22);
+      border-radius: 8px;
+    }
+
+    .form-type-btn {
+      flex: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 6px;
+      padding: 6px 12px;
+      border: none;
+      border-radius: 6px;
+      background: transparent;
+      color: rgba(255, 255, 255, 0.88);
+      font-size: 0.85rem;
+      font-weight: 500;
+      cursor: pointer;
+      white-space: nowrap;
+
+      &:hover:not(.active) {
+        background: rgba(255, 255, 255, 0.12);
+      }
+
+      &.active {
+        background: white;
+        color: $primary;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.12);
+      }
+    }
+
     .btn-back {
       background: rgba(255, 255, 255, 0.2);
       border: 1px solid rgba(255, 255, 255, 0.3);
@@ -1586,6 +1760,46 @@ export default {
       svg {
         font-size: 0.9rem;
       }
+    }
+  }
+
+  .form-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 8px 16px;
+    background: #eef6fc;
+    border-bottom: 1px solid var(--color-border);
+    flex-shrink: 0;
+  }
+
+  .form-toolbar-hint {
+    margin: 0;
+    font-size: 0.82rem;
+    color: var(--color-text);
+    opacity: 0.8;
+    line-height: 1.4;
+  }
+
+  .form-toolbar-check {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    font-size: 0.82rem;
+    font-weight: 500;
+    color: var(--color-heading);
+    white-space: nowrap;
+    cursor: pointer;
+    flex-shrink: 0;
+
+    .checkbox-input {
+      margin: 0;
+      width: 15px;
+      height: 15px;
+      accent-color: $primary;
+      cursor: pointer;
     }
   }
 
@@ -1917,6 +2131,22 @@ export default {
         padding: 4px 10px;
         font-size: 0.85rem;
       }
+
+      .form-type-switch {
+        flex: 1 1 100%;
+        max-width: none;
+        order: 3;
+      }
+    }
+
+    .form-toolbar {
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 8px;
+    }
+
+    .form-toolbar-check {
+      white-space: normal;
     }
 
     .form-content {

--- a/medcat-trainer/webapp/uv.lock
+++ b/medcat-trainer/webapp/uv.lock
@@ -1218,7 +1218,7 @@ wheels = [
 
 [[package]]
 name = "medcat"
-version = "2.8.3"
+version = "2.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1235,9 +1235,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "xxhash" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2b/43/35100059197afbf8d6e508629de754b3a41723698e0c8391578bb93dd8dd/medcat-2.8.3.tar.gz", hash = "sha256:f6041afbbaa648e0bbff314cf991b833af5712168567ccdcd0d53ba6253b7be6", size = 959464, upload-time = "2026-06-17T11:56:48.146Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/b4/74f88348bbe1eeaddb0c86c45d8f7e9be81409644faf5b59a98b4979805a/medcat-2.8.6.tar.gz", hash = "sha256:241d85ed546711ed0bb427b49e1fc02824f9310bca0ca3ad8f0e4527d4697b31", size = 960026, upload-time = "2026-06-23T15:58:34.681Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c3/05/84cd3ef73ba0e6a73973a492c8c71d6e5d3962f913b8f93a7d4222f7949f/medcat-2.8.3-py3-none-any.whl", hash = "sha256:8f482a3b6190fe84fad1dce905d4c965ad2fe6996f8dd453079731e33fe83b1e", size = 317225, upload-time = "2026-06-17T11:56:46.448Z" },
+    { url = "https://files.pythonhosted.org/packages/06/b0/3411e675d004f5823ef50fa6804cd73e6185f1445c82ac578a4cd7dc2582/medcat-2.8.6-py3-none-any.whl", hash = "sha256:726dfdd9fc1afafbce5ace3cef58412d0de40d6ef89767bb162ad77cb1386e74", size = 317522, upload-time = "2026-06-23T15:58:32.487Z" },
 ]
 
 [package.optional-dependencies]
@@ -1319,7 +1319,7 @@ requires-dist = [
     { name = "django-polymorphic", specifier = ">=4.0,<5" },
     { name = "djangorestframework", specifier = ">=3.16,<4" },
     { name = "drf-oidc-auth", specifier = ">=3.0" },
-    { name = "medcat", extras = ["meta-cat", "spacy", "rel-cat", "deid", "dict-ner"], specifier = ">=2.8.3" },
+    { name = "medcat", extras = ["meta-cat", "spacy", "rel-cat", "deid", "dict-ner"], specifier = ">=2.8.6" },
     { name = "openpyxl", specifier = ">=3.1" },
     { name = "opentelemetry-api", specifier = ">=1.0.0,<2" },
     { name = "opentelemetry-distro", extras = ["otlp"], marker = "extra == 'observability'", specifier = ">=0.61b0" },


### PR DESCRIPTION
- `/project-admin/` now can create `ProjectGroup` objects that are multiple duplicated `ProjectAnnotateEntities` with the same dataset and other configuration settings. 
- There are duplicate `ProjectAnnotateEntities` for each 'Annotator' user.
- Improved the UI for how `ProjectGroup` appear in the main UI. 