### PR TITLE
feat(medcat-tutorials): Add custom addon tutorial

### DIFF
--- a/medcat-v2-tutorials/mkdocs.yml
+++ b/medcat-v2-tutorials/mkdocs.yml
@@ -51,6 +51,7 @@ nav:
   - Advanced Tutorials:
     - 1. Creating and using a custom tokenizer: advanced/1._Creating_and_using_a_custom_tokenizer.ipynb
     - 2. Create and use component: advanced/2._Create_and_use_component.ipynb
+    - 3. Create and use a custom addon: advanced/3._Create_and_use_a_custom_addon.ipynb
     - Custom Components:
       - README: introductory/custom/README.md
       - 1. Create Modelpack with 2step linker: introductory/custom/1._Create_Modelpack_with_2step_linker.ipynb

--- a/medcat-v2-tutorials/notebooks/advanced/3._Create_and_use_a_custom_addon.ipynb
+++ b/medcat-v2-tutorials/notebooks/advanced/3._Create_and_use_a_custom_addon.ipynb
@@ -1,0 +1,349 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "44014e4d",
+   "metadata": {},
+   "source": [
+    "# How to create and use a custom addon\n",
+    "\n",
+    "This part of the tutorial focuses on addon creations.\n",
+    "Addons are components that run in addition to (and after) the core components (tagging, normalization, ner, and linking).\n",
+    "They can be provided by the core library (e.g MetaCAT or RelCAT which are available as optional addons when isntalling `medcat`) or by external packages.\n",
+    "\n",
+    "An addon has full access to the output of the model.\n",
+    "So it can change, add, or remove entities to the output.\n",
+    "Or, it can add extra data / context to entities."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f6599954",
+   "metadata": {},
+   "source": [
+    "## Example of a post-processing addon\n",
+    "\n",
+    "We will create an example addon that does some post processing.\n",
+    "For the example, we will <filter out all names that have 'no' in them?>, but for actual use cases you may need a more sophisticated system for this.\n",
+    "But we do imagine someone might want to add an additional addon that uses the output of MetaCAT to filter out concepts that are negated and/or not related to the patient at hand."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "556a0ad1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from medcat.components.addons.addons import AddonComponent\n",
+    "from medcat.components.addons.addons import register_addon\n",
+    "from medcat.tokenizing.tokenizers import BaseTokenizer\n",
+    "from medcat.tokenizing.tokens import MutableDocument, MutableEntity\n",
+    "from medcat.config.config import ComponentConfig\n",
+    "from medcat.cdb import CDB\n",
+    "from medcat.vocab import Vocab\n",
+    "\n",
+    "\n",
+    "_ADDON_NAME = 'post-filter'\n",
+    "\n",
+    "\n",
+    "class ConfigPostFilter(ComponentConfig):\n",
+    "    # inherited\n",
+    "    comp_name: str = _ADDON_NAME\n",
+    "    # specific to this\n",
+    "    filter_string: str = 'no'\n",
+    "\n",
+    "    def should_keep(self, entity: MutableEntity) -> bool:\n",
+    "        return self.filter_string not in entity.text.lower()\n",
+    "\n",
+    "\n",
+    "ADDON_DATA_PATH_DOC = 'post-filter-doc-data'\n",
+    "ADDON_DATA_PATH_ENT = 'post-filter-entity-data'\n",
+    "\n",
+    "\n",
+    "class PostFilteringAddon(AddonComponent):\n",
+    "    addon_type = _ADDON_NAME\n",
+    "    output_key = _ADDON_NAME\n",
+    "    config: ConfigPostFilter\n",
+    "\n",
+    "    def __init__(self, config: ConfigPostFilter, base_tokenizer: BaseTokenizer) -> None:\n",
+    "        self.config = config\n",
+    "        # NOTE: allows us to have multiple with different filters if we like\n",
+    "        self._name = f\"F-{config.filter_string}\"\n",
+    "        self._init_data_paths(base_tokenizer)\n",
+    "\n",
+    "    @classmethod\n",
+    "    def create_new_component(\n",
+    "            cls, cnf: ConfigPostFilter, tokenizer: BaseTokenizer,\n",
+    "            cdb: CDB, vocab: Vocab, model_load_path: str | None,\n",
+    "            ) -> 'PostFilteringAddon':\n",
+    "        return cls(cnf, tokenizer)\n",
+    "\n",
+    "    @property\n",
+    "    def name(self) -> str:\n",
+    "        return str(self._name)\n",
+    "\n",
+    "    def _inference(self, doc: MutableDocument) -> MutableDocument:\n",
+    "        ents_start = len(doc.linked_ents)\n",
+    "        for ent in list(doc.linked_ents):\n",
+    "            if not self.config.should_keep(ent):\n",
+    "                # if not to keep, remove\n",
+    "                doc.linked_ents.remove(ent)\n",
+    "                # but mark in entity that it was removed\n",
+    "                ent.set_addon_data(\n",
+    "                    ADDON_DATA_PATH_ENT,\n",
+    "                    # kept?, reason\n",
+    "                    (False, \"not allowed by filter\")\n",
+    "                )\n",
+    "            else:\n",
+    "                ent.set_addon_data(\n",
+    "                    ADDON_DATA_PATH_ENT,\n",
+    "                    # kept?, reason\n",
+    "                    (True, \"allowed by filter\")\n",
+    "                )\n",
+    "        ents_end = len(doc.linked_ents)\n",
+    "        doc.set_addon_data(\n",
+    "            ADDON_DATA_PATH_DOC, (ents_start, ents_end)\n",
+    "        )\n",
+    "        return doc\n",
+    "\n",
+    "    def __call__(self, doc: MutableDocument) -> MutableDocument:\n",
+    "        return self._inference(doc)\n",
+    "\n",
+    "    def _init_data_paths(self, base_tokenizer: BaseTokenizer):\n",
+    "        # NOTE: only stuff from the entity class will propagate into\n",
+    "        #       the output json in the end\n",
+    "        base_tokenizer.get_entity_class().register_addon_path(\n",
+    "            ADDON_DATA_PATH_ENT, def_val=None, force=True)\n",
+    "        # if you wish something saved on a per document basis, use this:\n",
+    "        base_tokenizer.get_doc_class().register_addon_path(\n",
+    "            ADDON_DATA_PATH_DOC, def_val=None, force=True)\n",
+    "        # NOTE: the per-document data does not get automatically written\n",
+    "        #       to the output of get_entitites\n",
+    "\n",
+    "    # NOTE: this will need to be implemented and return True\n",
+    "    #       if you wish the output included in get_entities\n",
+    "    @property\n",
+    "    def include_in_output(self) -> bool:\n",
+    "        return True\n",
+    "\n",
+    "    def get_output_key_val(self, ent: MutableEntity\n",
+    "                           ) -> tuple[str, tuple[bool, str]]:\n",
+    "        return self.output_key, ent.get_addon_data(ADDON_DATA_PATH_ENT)\n",
+    "\n",
+    "\n",
+    "# register component\n",
+    "register_addon(PostFilteringAddon.addon_type, PostFilteringAddon.create_new_component)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d159b8a8",
+   "metadata": {},
+   "source": [
+    "## Using the component\n",
+    "\n",
+    "Now we need to use this component as part of a pipe.\n",
+    "So we will download a model, load it up, and add this addon to it.\n",
+    "\n",
+    "### First we add it to the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "3589b00e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "mkdir: illegal option -- P\n",
+      "usage: mkdir [-pv] [-m mode] directory_name ...\n",
+      "--2026-08-14 14:40:58--  https://cogstack-medcat-example-models.s3.eu-west-2.amazonaws.com/medcat-example-models/medmen_wstatus_2021_oct.zip\n",
+      "Resolving cogstack-medcat-example-models.s3.eu-west-2.amazonaws.com (cogstack-medcat-example-models.s3.eu-west-2.amazonaws.com)... 52.95.148.18, 3.5.245.207, 52.95.142.42, ...\n",
+      "Connecting to cogstack-medcat-example-models.s3.eu-west-2.amazonaws.com (cogstack-medcat-example-models.s3.eu-west-2.amazonaws.com)|52.95.148.18|:443... connected.\n",
+      "HTTP request sent, awaiting response... 304 Not Modified\n",
+      "File ‘models/medmen_wstatus_2021_oct.zip’ not modified on server. Omitting download.\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Doing legacy conversion on CAT (at 'models/medmen_wstatus_2021_oct'). Set the environment variable MEDCAT_AVOID_LECACY_CONVERSION to `True` to avoid this.\n",
+      "Missing class medcat.config.weighted_average, replacing with LegacyClassNotFound.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Conditions False False IN {'T125', 'T057', 'T103', 'T086', 'T040', 'T037', 'T025', 'T070', 'T017', 'T095', 'T067', 'T047', 'T097', 'T109', 'T014', 'T007', 'T167', 'T042', 'T013', 'T030', 'T184', 'T064', 'T096', 'T102', 'T016', 'T056', 'T114', 'T075', 'T201', 'T100', 'T029', 'T099', 'T031', 'T092', 'T049', 'T120', 'T043', 'T019', 'T044', 'T041', 'T171', 'T066', 'T169', 'T038', 'T023', 'T170', 'T191', 'T020', 'T116', 'T127', 'T080', 'T093', 'T026', 'T050', 'T098', 'T065', 'T011', 'T104', 'T131', 'T072', 'T052', 'T051', 'T090', 'T085', 'T078', 'T081', 'T054', 'T123', 'T069', 'T028', 'T073', 'T091', 'T053', 'unk', 'T015', 'T004', 'T061', 'T121', 'T079', 'T002', 'T055', 'T129', 'T203', 'T033', 'T077', 'T190', 'T034', 'T204', 'T122', 'T010', 'T060', 'T089', 'T005', 'T001', 'T168', 'T018', 'T024', 'T059', 'T083', 'T087', 'T194', 'T039', 'T032', 'T071', 'T012', 'T021', 'T022', 'T196', 'T046', 'T094', 'T101', 'T048', 'T082', 'T197', 'T200', 'T130', 'T062', 'T185', 'T063', 'T195', 'T008', 'T126', 'T045', 'T068', 'T192', 'T058', 'T074'}\n",
+      "Got TypeID2name for 127 TypeIDs out of 127\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Trying to set 'cdb_source_name' for 'General' but no such attribute\n",
+      "Trying to set 'weighted_average_function' for 'Linking' but no such attribute\n",
+      "Optional path 'version.description' not found in old config. Ignoring\n",
+      "Optional path 'version.id' not found in old config. Ignoring\n",
+      "Optional path 'version.ontology' not found in old config. Ignoring\n",
+      "/Users/martratas/Documents/CogStack/.MedCAT.nosync/monorepo-nlp/medcat-v2-tutorials/.venv312/lib/python3.12/site-packages/spacy/util.py:969: UserWarning: [W095] Model 'en_core_web_md' (3.1.0) was trained with spaCy v3.1.0 and may not be 100% compatible with the current version (3.8.11). If you see errors or degraded performance, download a newer compatible model or retrain your custom model with the current spaCy version. For more details and available updates, run: python -m spacy validate\n",
+      "  warnings.warn(warn_msg)\n",
+      "/Users/martratas/Documents/CogStack/.MedCAT.nosync/monorepo-nlp/medcat-v2-tutorials/.venv312/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "PIPE:\n",
+      " {'core': {'tagging': {'name': 'tag-and-skip-tagger', 'provider': 'medcat'}, 'token_normalizing': {'name': 'token_normalizer', 'provider': 'medcat'}, 'ner': {'name': 'cat_ner', 'provider': 'medcat'}, 'linking': {'name': 'medcat2_linker', 'provider': 'medcat'}}, 'addons': [{'name': 'Status', 'provider': 'medcat'}, {'name': 'F-no', 'provider': 'medcat'}]}\n"
+     ]
+    }
+   ],
+   "source": [
+    "! mkdir -P models/\n",
+    "! wget -N https://cogstack-medcat-example-models.s3.eu-west-2.amazonaws.com/medcat-example-models/medmen_wstatus_2021_oct.zip -P models/\n",
+    "\n",
+    "MODEL_PATH = \"models/\"\n",
+    "\n",
+    "import os\n",
+    "from medcat.cat import CAT\n",
+    "\n",
+    "\n",
+    "model_path = os.path.join(\"models\", \"medmen_wstatus_2021_oct.zip\")\n",
+    "\n",
+    "cat = CAT.load_model_pack(model_path)\n",
+    "# need to fix on a legacy model:\n",
+    "cat.config.components.linking.train = False\n",
+    "\n",
+    "# create the addon\n",
+    "from medcat.components.addons.addons import create_addon\n",
+    "\n",
+    "cnf = ConfigPostFilter()\n",
+    "# this also ensure that it was correctly registered\n",
+    "# and that the standardised hook to create the addon is working\n",
+    "# as intended\n",
+    "addon = create_addon(\n",
+    "    PostFilteringAddon.addon_type,\n",
+    "    cnf,\n",
+    "    cat.pipe.tokenizer,\n",
+    "    cat.cdb,\n",
+    "    cat.vocab,\n",
+    "    None,\n",
+    ")\n",
+    "\n",
+    "# add the addon to the model\n",
+    "cat.add_addon(addon)\n",
+    "\n",
+    "print(\"PIPE:\\n\", cat.describe_pipeline())\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "043d6714",
+   "metadata": {},
+   "source": [
+    "### Now we use it\n",
+    "\n",
+    "Now that we have a model with the addon, we can use the entire pipe with our addon in it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "804ce03e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Per doc data: (2, 1)\n",
+      "Inspecting raw NER entities\n",
+      "Entity M2W[T]:normal C0205307 (False, 'not allowed by filter')\n",
+      "Entity M2W[T]:fever C0015967 (True, 'allowed by filter')\n",
+      "Now for regular get_entities()\n",
+      "{1: {'acc': 0.7370152793602454,\n",
+      "     'context_center': [],\n",
+      "     'context_left': [],\n",
+      "     'context_right': [],\n",
+      "     'context_similarity': 0.7370152793602454,\n",
+      "     'cui': 'C0015967',\n",
+      "     'detected_name': 'fever',\n",
+      "     'end': 33,\n",
+      "     'id': 1,\n",
+      "     'meta_anns': {'Status': {'confidence': 0.9999959468841553,\n",
+      "                              'name': 'Status',\n",
+      "                              'value': 'Other'}},\n",
+      "     'post-filter': (True, 'allowed by filter'),\n",
+      "     'pretty_name': 'Fever',\n",
+      "     'source_value': 'fever',\n",
+      "     'start': 28,\n",
+      "     'type_ids': ['T184']}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pprint import pprint\n",
+    "text = (\n",
+    "    # normal has 'no' so should be removed\n",
+    "    \"John felt normal. \"\n",
+    "    # fever does not so should be kept\n",
+    "    \"He had no fever.\"\n",
+    ")\n",
+    "\n",
+    "# let's look at the document for the addon data\n",
+    "doc = cat(text)\n",
+    "doc_data = doc.get_addon_data(ADDON_DATA_PATH_DOC)\n",
+    "# NOTE: again, this doesn't get written into the output of get_entities\n",
+    "print(\"Per doc data:\", doc_data)\n",
+    "\n",
+    "print(\"Inspecting raw NER entities\")\n",
+    "# we can still investiaget the raw NER entity\n",
+    "# these will include the ones that were later rejected\n",
+    "# by our filter\n",
+    "for ent in doc.ner_ents:\n",
+    "    addon_output = cat.get_addon_output(ent)\n",
+    "    print(\"Entity\", ent, ent.cui, addon_output['post-filter'])\n",
+    "\n",
+    "print(\"Now for regular get_entities()\")\n",
+    "\n",
+    "# NOTE: you don't normally want to call the above AND this - that\n",
+    "#       would run the entire pipe ofer the same text twice.\n",
+    "#       So stick to one or the other as needed\n",
+    "ents = cat.get_entities(text)['entities']\n",
+    "pprint(ents)\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv312 (3.12.10)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds a totorial regarding custom addons.

This should make it easier for someone to create one in the way that they were intended to be used.

The notebook can be seen here:
https://github.com/CogStack/cogstack-nlp/blob/feat/medcat-tutorials/add-custom-addon-tutorial/medcat-v2-tutorials/notebooks/advanced/3._Create_and_use_a_custom_addon.ipynb