### PR TITLE
feat(medcat): Avoid misconfigured components

### DIFF
--- a/medcat-v2/medcat/pipeline/pipeline.py
+++ b/medcat-v2/medcat/pipeline/pipeline.py
@@ -346,8 +346,18 @@ class Pipeline:
             logger.info("Running component %s for %d of text (%s)",
                         comp.full_name, len(text), id(text))
             doc = comp(doc)
+            if doc is None:
+                raise IncorrectCoreComponent(
+                    f"Core component {comp.full_name} returned None "
+                    "instead of the document."
+                )
         for addon in self._addons:
             doc = addon(doc)
+            if doc is None:
+                raise IncorrectAddonComponent(
+                    f"Addon component {addon.full_name} returned None "
+                    "instead of the document."
+                )
         return doc
 
     def entity_from_tokens(self, tokens: list[MutableToken]) -> MutableEntity:
@@ -463,6 +473,12 @@ class IncorrectArgumentsForComponent(TypeError):
 
 
 class IncorrectCoreComponent(ValueError):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+
+class IncorrectAddonComponent(ValueError):
 
     def __init__(self, *args):
         super().__init__(*args)

--- a/medcat-v2/tests/pipeline/test_pipeline.py
+++ b/medcat-v2/tests/pipeline/test_pipeline.py
@@ -1,10 +1,16 @@
+from contextlib import contextmanager
+from typing import runtime_checkable
+from medcat.components.types import CoreComponentType
+from medcat.config.config_meta_cat import ConfigMetaCAT
 from medcat.pipeline import pipeline
+from medcat.tokenizing.tokens import MutableDocument
 from medcat.vocab import Vocab
 from medcat.config import Config
 
 from ..components.ner.test_vocab_based_ner import FakeCDB as BFakeCDB
 
 import unittest
+import unittest.mock
 
 
 class FakeCDB(BFakeCDB):
@@ -18,8 +24,11 @@ class FakeCDB(BFakeCDB):
     def weighted_average_function(self, v: int) -> float:
         return v / 2.0
 
+    def has_subname(self, sn: str) -> bool:
+        return sn in self.name2info
 
-class PlatformInitTests(unittest.TestCase):
+
+class PipelineInitTests(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -30,3 +39,64 @@ class PlatformInitTests(unittest.TestCase):
     def test_can_create_pipeline(self):
         pf = pipeline.Pipeline(self.cdb, self.vocab, None)
         self.assertIsInstance(pf, pipeline.Pipeline)
+
+
+class PipelineComponentTests(unittest.TestCase):
+    text = "example text"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cnf = cls._init_cnf()
+        cls.cdb = FakeCDB(cls.cnf)
+        cls.vocab = Vocab()
+        cls.pipe = pipeline.Pipeline(cls.cdb, cls.vocab, None)
+
+    @classmethod
+    def _init_cnf(cls):
+        cnf = Config()
+        meta_cat_cnf = ConfigMetaCAT()
+        cnf.components.addons.append(meta_cat_cnf)
+        return cnf
+
+    def test_pipe_works_normally(self):
+        doc = self.pipe.get_doc(self.text)
+        self.assertIsInstance(doc, runtime_checkable(MutableDocument))
+
+    @contextmanager
+    def none_returning_core_comp(
+            self, cct: CoreComponentType = CoreComponentType.linking):
+        linker = self.pipe.get_component(cct)
+        linker_cls = linker.__class__
+        orig_call = linker_cls.__call__
+
+        def new_call(*args, **kwargs):
+            orig_call(*args, **kwargs)
+            return None
+        with unittest.mock.patch.object(
+            linker_cls, '__call__', new_call
+        ):
+            yield
+
+    @contextmanager
+    def none_returning_addon(self):
+        addon = next(self.pipe.iter_addons())
+        addon_cls = addon.__class__
+        orig_call = addon_cls.__call__
+
+        def new_call(*args, **kwargs):
+            orig_call(*args, **kwargs)
+            return None
+        with unittest.mock.patch.object(
+            addon_cls, '__call__', new_call
+        ):
+            yield
+
+    def test_core_components_cannot_return_none(self):
+        with self.none_returning_core_comp():
+            with self.assertRaises(pipeline.IncorrectCoreComponent):
+                self.pipe.get_doc(self.text)
+
+    def test_addon_components_cannot_return_none(self):
+        with self.none_returning_addon():
+            with self.assertRaises(pipeline.IncorrectAddonComponent):
+                self.pipe.get_doc(self.text)


### PR DESCRIPTION
This PR makes sure that the pipe does not tolerate components that return `None`.

This should help people who implement their own components better understand why their component might be silently  breaking the entire pipe.
Up until now, if the last component in the pipe returned `None`, this would propagate as the return value from `CAT.__call__` or result in empty dict output from `CAT.get_entities()`.

This can easily happen if/when creating a new component and forgetting the `return` statement in the `__call__` method.

NOTE:
Previously, if a component that was NOT the last component in the pipe, it would likely still break the pipe, but that would be due to the following component expecting a `MutableDocument` rather than `None`. So even in these cases the exception is now much clearer on the issue.