### PR TITLE
fix(medcat-den): CPDT-171 Fix den model load api for core lib 2.9

### DIFF
--- a/medcat-den/src/medcat_den/wrappers.py
+++ b/medcat-den/src/medcat_den/wrappers.py
@@ -1,10 +1,11 @@
-from typing import Union, Optional
+from typing import Union, Optional, Type
 
 from medcat.cat import CAT
 from medcat.utils.defaults import DEFAULT_PACK_NAME
 from medcat.storage.serialisers import AvailableSerialisers
 from medcat.trainer import Trainer
 from medcat.data.mctexport import MedCATTrainerExport
+from medcat.components.addons.addons import AddonComponent
 
 from medcat_den.base import ModelInfo
 from medcat_den.config import DenConfig, RemoteDenConfig
@@ -92,6 +93,7 @@ class CATWrapper(CAT):
                         addon_config_dict: Optional[dict[str, dict]] = None,
                         model_info: Optional[ModelInfo] = None,
                         den_cnf: Optional[DenConfig] = None,
+                        keep_addons_of_types: Optional[list[Type[AddonComponent]]] = None,
                         ) -> 'CAT':
         """Load the model pack from file.
 

--- a/medcat-den/src/medcat_den/wrappers.py
+++ b/medcat-den/src/medcat_den/wrappers.py
@@ -123,7 +123,9 @@ class CATWrapper(CAT):
             CAT: The loaded model pack.
         """
         _cat = super().load_model_pack(
-            model_pack_path, config_dict, addon_config_dict)
+            model_pack_path, config_dict, addon_config_dict,
+            keep_addons_of_types=keep_addons_of_types,
+        )
         cat = cls(_cat)
         if model_info is None:
             raise CannotWrapModel("Model info must be provided")

--- a/medcat-den/src/medcat_den/wrappers.py
+++ b/medcat-den/src/medcat_den/wrappers.py
@@ -91,9 +91,9 @@ class CATWrapper(CAT):
     def load_model_pack(cls, model_pack_path: str,
                         config_dict: Optional[dict] = None,
                         addon_config_dict: Optional[dict[str, dict]] = None,
+                        keep_addons_of_types: Optional[list[Type[AddonComponent]]] = None,
                         model_info: Optional[ModelInfo] = None,
                         den_cnf: Optional[DenConfig] = None,
-                        keep_addons_of_types: Optional[list[Type[AddonComponent]]] = None,
                         ) -> 'CAT':
         """Load the model pack from file.
 


### PR DESCRIPTION
This PR fixs MedCAT den workflow by updating the API in line with medcat==2.9.0 where a new (optional) argument was added to `CAT.load_model_pack`.